### PR TITLE
Adds define NETWORK_DEFAULT_ADDRESS

### DIFF
--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -254,6 +254,11 @@ uint8_t RF24Network::update(void)
 				
 				if(multicastRelay){					
 					IF_SERIAL_DEBUG_ROUTING( printf_P(PSTR("%u MAC: FWD multicast frame from 0%o to level %u\n"),millis(),header->from_node,multicast_level+1); );
+					if ((node_address >> 3) != 0) {
+					  // for all but the first level of nodes, those not directly connected to the master, we add the total delay per level
+					  delayMicroseconds(700*4);
+					}
+					delayMicroseconds((node_address % 4)*700);
 					write(levelToAddress(multicast_level)<<3,4);
 				}
 				if( val == 2 ){ //External data received			

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -256,9 +256,9 @@ uint8_t RF24Network::update(void)
 					IF_SERIAL_DEBUG_ROUTING( printf_P(PSTR("%u MAC: FWD multicast frame from 0%o to level %u\n"),millis(),header->from_node,multicast_level+1); );
 					if ((node_address >> 3) != 0) {
 					  // for all but the first level of nodes, those not directly connected to the master, we add the total delay per level
-					  delayMicroseconds(700*4);
+					  delayMicroseconds(600*4);
 					}
-					delayMicroseconds((node_address % 4)*700);
+					delayMicroseconds((node_address % 4)*600);
 					write(levelToAddress(multicast_level)<<3,4);
 				}
 				if( val == 2 ){ //External data received			
@@ -1153,7 +1153,11 @@ void RF24Network::setup_address(void)
   }
   parent_pipe = i;
 
-  IF_SERIAL_DEBUG_MINIMAL( printf_P(PSTR("setup_address node=0%o mask=0%o parent=0%o pipe=0%o\n\r"),node_address,node_mask,parent_node,parent_pipe););
+//  IF_SERIAL_DEBUG_MINIMAL( printf_P(PSTR("setup_address node=0%o mask=0%o parent=0%o pipe=0%o\n\r"),node_address,node_mask,parent_node,parent_pipe););
+  IF_SERIAL_DEBUG_MINIMAL(Serial.print(F("setup_address node=")));
+  IF_SERIAL_DEBUG_MINIMAL(Serial.print(node_address,OCT));
+  IF_SERIAL_DEBUG_MINIMAL(Serial.print(F(" parent=")));
+  IF_SERIAL_DEBUG_MINIMAL(Serial.println(parent_node,OCT));
 
 }
 

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -1153,11 +1153,11 @@ void RF24Network::setup_address(void)
   }
   parent_pipe = i;
 
-//  IF_SERIAL_DEBUG_MINIMAL( printf_P(PSTR("setup_address node=0%o mask=0%o parent=0%o pipe=0%o\n\r"),node_address,node_mask,parent_node,parent_pipe););
-  IF_SERIAL_DEBUG_MINIMAL(Serial.print(F("setup_address node=")));
-  IF_SERIAL_DEBUG_MINIMAL(Serial.print(node_address,OCT));
-  IF_SERIAL_DEBUG_MINIMAL(Serial.print(F(" parent=")));
-  IF_SERIAL_DEBUG_MINIMAL(Serial.println(parent_node,OCT));
+  IF_SERIAL_DEBUG_MINIMAL( printf_P(PSTR("setup_address node=0%o mask=0%o parent=0%o pipe=0%o\n\r"),node_address,node_mask,parent_node,parent_pipe););
+//  IF_SERIAL_DEBUG_MINIMAL(Serial.print(F("setup_address node=")));
+//  IF_SERIAL_DEBUG_MINIMAL(Serial.print(node_address,OCT));
+//  IF_SERIAL_DEBUG_MINIMAL(Serial.print(F(" parent=")));
+//  IF_SERIAL_DEBUG_MINIMAL(Serial.println(parent_node,OCT));
 
 }
 

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -202,7 +202,7 @@ uint8_t RF24Network::update(void)
 			   continue;
 			}
 		    if(header->type == NETWORK_ADDR_RESPONSE ){	
-			    uint16_t requester = 04444;
+			    uint16_t requester = NETWORK_DEFAULT_ADDRESS;
 				if(requester != node_address){
 					header->to_node = requester;
 					write(header->to_node,USER_TX_TO_PHYSICAL_ADDRESS);
@@ -242,7 +242,7 @@ uint8_t RF24Network::update(void)
 			
 
 				if(header->type == NETWORK_POLL  ){
-                    if( !(networkFlags & FLAG_NO_POLL) && node_address != 04444 ){
+                    if( !(networkFlags & FLAG_NO_POLL) && node_address != NETWORK_DEFAULT_ADDRESS ){
 					  header->to_node = header->from_node;
 					  header->from_node = node_address;			
 					  delay(parent_pipe);

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -7,6 +7,8 @@
  version 2 as published by the Free Software Foundation.
  */
 
+#define NETWORK_DEFAULT_ADDRESS 04444
+
 #ifndef __RF24NETWORK_CONFIG_H__
 #define __RF24NETWORK_CONFIG_H__
 

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -7,10 +7,11 @@
  version 2 as published by the Free Software Foundation.
  */
 
-#define NETWORK_DEFAULT_ADDRESS 04444
 
 #ifndef __RF24NETWORK_CONFIG_H__
 #define __RF24NETWORK_CONFIG_H__
+
+#define NETWORK_DEFAULT_ADDRESS 04444
 
   #if !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny84__)
 


### PR DESCRIPTION
Changing the MESH_DEFAULT_ADDRESS in RF24Mesh_config.h fails, as in RF24Network.cpp the network default address is hardcoded in two places. See also https://github.com/nRF24/RF24/issues/288.