### PR TITLE
Redefinition of returnVal removed

### DIFF
--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -193,7 +193,7 @@ uint8_t RF24Network::update(void)
 		continue;
 	  }
 	  
-	  uint8_t returnVal = header->type;
+      returnVal = header->type;
 
 	  // Is this for us?
       if ( header->to_node == node_address   ){


### PR DESCRIPTION
"returnVal" is defined twice. Fist time at the beginning of update().
I had Problems with Arduino to detect through traffic, "returnVal" was always 0.