### PR TITLE
Fix Python wrapper for peek functions

### DIFF
--- a/RPi/pyRF24Network/pyRF24Network.cpp
+++ b/RPi/pyRF24Network/pyRF24Network.cpp
@@ -61,7 +61,10 @@ std::string toString_wrap(RF24NetworkHeader& ref)
 	return std::string(ref.toString());
 }
 
-
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(
+    peekvoid, RF24Network::peek, 1, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(
+    peekint, RF24Network::peek, 1, 2)
 // **************** RF24Network exposed  *****************
 //
 BOOST_PYTHON_MODULE(RF24Network){
@@ -99,22 +102,22 @@ BOOST_PYTHON_MODULE(RF24Network){
         
         }
         { //::RF24Network::peek
-        
-            typedef uint16_t ( ::RF24Network::*peek_function_type )( ::RF24NetworkHeader & ) ;
-            
-            RF24Network_exposer.def( 
+
+            typedef uint16_t ( ::RF24Network::*peekint )( ::RF24NetworkHeader & ) ;
+
+            RF24Network_exposer.def(
                 "peek"
-                , peek_function_type( &::RF24Network::peek )
+                , peekint( &::RF24Network::peek )
                 , ( bp::arg("header") ) );
         
         }
         { //::RF24Network::peek
 
-            typedef bp::tuple ( *peek_function_type )( ::RF24Network& , size_t) ;
+            typedef bp::tuple ( *peekvoid )( ::RF24Network& , size_t) ;
 
             RF24Network_exposer.def(
                 "peek"
-                , peek_function_type( &read_wrap )
+                , peekvoid( &read_wrap )
                 , (bp::arg("maxlen") ) );
 
         }

--- a/RPi/pyRF24Network/pyRF24Network.cpp
+++ b/RPi/pyRF24Network/pyRF24Network.cpp
@@ -57,6 +57,7 @@ bp::tuple peek_read_wrap(RF24Network& ref, size_t maxlen)
 	RF24NetworkHeader header;
 
 	ref.peek(header, buf, maxlen);
+    uint16_t len = ref.peek(header);
     bp::object py_ba(bp::handle<>(PyByteArray_FromStringAndSize(buf, len)));
     delete[] buf;
 

--- a/RPi/pyRF24Network/pyRF24Network.cpp
+++ b/RPi/pyRF24Network/pyRF24Network.cpp
@@ -126,7 +126,7 @@ BOOST_PYTHON_MODULE(RF24Network){
         }
         { //::RF24Network::peek
 
-            typedef void ( *peekvoid )( ::RF24Network& , size_t) ;
+            typedef bp::tuple ( *peekvoid )( ::RF24Network& , size_t) ;
 
             RF24Network_exposer.def(
                 "peek"

--- a/RPi/pyRF24Network/pyRF24Network.cpp
+++ b/RPi/pyRF24Network/pyRF24Network.cpp
@@ -47,7 +47,19 @@ bp::tuple read_wrap(RF24Network& ref, size_t maxlen)
 	uint16_t len = ref.read(header, buf, maxlen);
     bp::object py_ba(bp::handle<>(PyByteArray_FromStringAndSize(buf, len)));
     delete[] buf;
-	
+
+	return bp::make_tuple(header, py_ba);
+}
+
+bp::tuple peek_read_wrap(RF24Network& ref, size_t maxlen)
+{
+	char *buf = new char[maxlen+1];
+	RF24NetworkHeader header;
+
+	ref.peek(header, buf, maxlen);
+    bp::object py_ba(bp::handle<>(PyByteArray_FromStringAndSize(buf, len)));
+    delete[] buf;
+
 	return bp::make_tuple(header, py_ba);
 }
 
@@ -117,7 +129,7 @@ BOOST_PYTHON_MODULE(RF24Network){
 
             RF24Network_exposer.def(
                 "peek"
-                , peekvoid( &read_wrap )
+                , peekvoid( &peek_read_wrap )
                 , (bp::arg("maxlen") ) );
 
         }

--- a/RPi/pyRF24Network/pyRF24Network.cpp
+++ b/RPi/pyRF24Network/pyRF24Network.cpp
@@ -108,6 +108,16 @@ BOOST_PYTHON_MODULE(RF24Network){
                 , ( bp::arg("header") ) );
         
         }
+        { //::RF24Network::peek
+
+            typedef bp::tuple ( *peek_function_type )( ::RF24Network& , size_t) ;
+
+            RF24Network_exposer.def(
+                "peek"
+                , peek_function_type( &read_wrap )
+                , (bp::arg("maxlen") ) );
+
+        }
         { //::RF24Network::read
         
             typedef bp::tuple ( *read_function_type )(::RF24Network&, size_t ) ;

--- a/RPi/pyRF24Network/pyRF24Network.cpp
+++ b/RPi/pyRF24Network/pyRF24Network.cpp
@@ -100,7 +100,7 @@ BOOST_PYTHON_MODULE(RF24Network){
         }
         { //::RF24Network::peek
         
-            typedef void ( ::RF24Network::*peek_function_type )( ::RF24NetworkHeader & ) ;
+            typedef uint16_t ( ::RF24Network::*peek_function_type )( ::RF24NetworkHeader & ) ;
             
             RF24Network_exposer.def( 
                 "peek"

--- a/RPi/pyRF24Network/pyRF24Network.cpp
+++ b/RPi/pyRF24Network/pyRF24Network.cpp
@@ -113,7 +113,7 @@ BOOST_PYTHON_MODULE(RF24Network){
         }
         { //::RF24Network::peek
 
-            typedef bp::tuple ( *peekvoid )( ::RF24Network& , size_t) ;
+            typedef void ( *peekvoid )( ::RF24Network& , size_t) ;
 
             RF24Network_exposer.def(
                 "peek"


### PR DESCRIPTION
Updated the Python wrapper for the expanded peek functionality from #106.

Original peek function in the wrapper function has had the `uint_16t` added in the type definition. Also, the expanded functionality introduced in #106 has been added to a second Python function.

Has been tested with various calls to the peek function to verify that any implementation of peek prior to #106 will still work with the addition to allow for the expanded functionality. Also, tested new calls of the peek to verify that they do call the two separate peek functions.