### PR TITLE
deploy docs using gh-pages

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -2,9 +2,17 @@ name: DoxyGen build
 
 on:
   pull_request:
+    branches:
+      - master
   push:
+    branches:
+      - master
   release:
-    types: [published, edited]
+    branches:
+      - master
+    types:
+      - published
+      - edited
 
 jobs:
   build-doxygen:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,37 @@
+name: DoxyGen build
+
+on:
+  pull_request:
+  push:
+  release:
+    types: [published, edited]
+
+jobs:
+  build-doxygen:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: get latest release version number
+      id: latest_ver
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        repository: nRF24/RF24Network
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: overwrite doxygen tags
+      run: |
+        mkdir docs
+        touch doxygenAction
+        echo "PROJECT_NUMBER = ${{ steps.latest_ver.outputs.release }}" >> doxygenAction
+        echo "@INCLUDE = doxygenAction" >> Doxyfile
+    - name: build doxygen
+      uses: mattnotmitt/doxygen-action@v1
+      with:
+          working-directory: '.'
+          doxyfile-path: './Doxyfile'
+    - name: upload to github pages
+      if: ${{ github.event_name == 'release'}}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/html

--- a/Doxyfile
+++ b/Doxyfile
@@ -230,12 +230,6 @@ TAB_SIZE               = 4
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all
@@ -839,7 +833,7 @@ EXCLUDE_SYMBOLS        =
 # command).
 
 EXAMPLE_PATH           = examples \
-                         RPi/RF24Network/examples
+                         examples_RPi
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -1634,7 +1628,7 @@ COMPACT_LATEX          = NO
 # The default value is: a4.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = a4
 
 # The EXTRA_PACKAGES tag can be used to specify one or more LaTeX package names
 # that should be included in the LaTeX output. The package can be specified just
@@ -2083,12 +2077,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2101,15 +2089,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
@@ -2151,7 +2130,7 @@ DOT_NUM_THREADS        = 0
 # The default value is: Helvetica.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTNAME           = FreeSans
+DOT_FONTNAME           =
 
 # The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
 # dot graphs.

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Newly Optimized RF24Network Layer"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 
+PROJECT_NUMBER         =
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -51,14 +51,14 @@ PROJECT_BRIEF          = "2020 - Optimized RF24 Network Layer for NRF24L01 radio
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = 
+PROJECT_LOGO           =
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = "../../ArduinoBuilds/RF24Network Docs"
+OUTPUT_DIRECTORY       = ./docs
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -118,7 +118,7 @@ REPEAT_BRIEF           = YES
 # the entity):The $name class, The $name widget, The $name file, is, provides,
 # specifies, contains, represents, a, an and the.
 
-ABBREVIATE_BRIEF       = 
+ABBREVIATE_BRIEF       =
 
 # If the ALWAYS_DETAILED_SEC and REPEAT_BRIEF tags are both set to YES then
 # doxygen will generate a detailed section even if there is only a brief
@@ -152,7 +152,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = 
+STRIP_FROM_PATH        =
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -161,7 +161,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    = 
+STRIP_FROM_INC_PATH    =
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -228,13 +228,13 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                = 
+ALIASES                =
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
 
-TCL_SUBST              = 
+TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -629,7 +629,7 @@ GENERATE_DEPRECATEDLIST= YES
 # sections, marked by \if <section_label> ... \endif and \cond <section_label>
 # ... \endcond blocks.
 
-ENABLED_SECTIONS       = 
+ENABLED_SECTIONS       =
 
 # The MAX_INITIALIZER_LINES tag determines the maximum number of lines that the
 # initial value of a variable or macro / define can have for it to appear in the
@@ -671,7 +671,7 @@ SHOW_NAMESPACES        = YES
 # by doxygen. Whatever the program writes to standard output is used as the file
 # version. For an example see the documentation.
 
-FILE_VERSION_FILTER    = 
+FILE_VERSION_FILTER    =
 
 # The LAYOUT_FILE tag can be used to specify a layout file which will be parsed
 # by doxygen. The layout file controls the global structure of the generated
@@ -684,7 +684,7 @@ FILE_VERSION_FILTER    =
 # DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
 # tag is left empty.
 
-LAYOUT_FILE            = 
+LAYOUT_FILE            =
 
 # The CITE_BIB_FILES tag can be used to specify one or more bib files containing
 # the reference definitions. This must be a list of .bib files. The .bib
@@ -694,7 +694,7 @@ LAYOUT_FILE            =
 # LATEX_BIB_STYLE. To use this feature you need bibtex and perl available in the
 # search path. See also \cite for info how to create references.
 
-CITE_BIB_FILES         = 
+CITE_BIB_FILES         =
 
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages
@@ -753,7 +753,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = 
+WARN_LOGFILE           =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
@@ -790,7 +790,7 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd,
 # *.vhdl, *.ucf, *.qsf, *.as and *.js.
 
-FILE_PATTERNS          = 
+FILE_PATTERNS          =
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -805,7 +805,7 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = 
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -832,7 +832,7 @@ EXCLUDE_PATTERNS       = bcm2835*
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = 
+EXCLUDE_SYMBOLS        =
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -846,7 +846,7 @@ EXAMPLE_PATH           = examples \
 # *.h) to filter out the source-files in the directories. If left blank all
 # files are included.
 
-EXAMPLE_PATTERNS       = 
+EXAMPLE_PATTERNS       =
 
 # If the EXAMPLE_RECURSIVE tag is set to YES then subdirectories will be
 # searched for input files to be used with the \include or \dontinclude commands
@@ -859,7 +859,7 @@ EXAMPLE_RECURSIVE      = YES
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = 
+IMAGE_PATH             =
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program
@@ -876,7 +876,7 @@ IMAGE_PATH             =
 # code is scanned, but not when the output code is generated. If lines are added
 # or removed, the anchors will not be placed correctly.
 
-INPUT_FILTER           = 
+INPUT_FILTER           =
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the
@@ -885,7 +885,7 @@ INPUT_FILTER           =
 # filters are used. If the FILTER_PATTERNS tag is empty or if none of the
 # patterns match the file name, INPUT_FILTER is applied.
 
-FILTER_PATTERNS        = 
+FILTER_PATTERNS        =
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for
@@ -900,14 +900,14 @@ FILTER_SOURCE_FILES    = NO
 # *.ext= (so without naming a filter).
 # This tag requires that the tag FILTER_SOURCE_FILES is set to YES.
 
-FILTER_SOURCE_PATTERNS = 
+FILTER_SOURCE_PATTERNS =
 
 # If the USE_MDFILE_AS_MAINPAGE tag refers to the name of a markdown file that
 # is part of the input, its contents will be placed on the main page
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = 
+USE_MDFILE_AS_MAINPAGE =
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -1012,7 +1012,7 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          = 
+CLANG_OPTIONS          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
@@ -1038,7 +1038,7 @@ COLS_IN_ALPHA_INDEX    = 10
 # while generating the index headers.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-IGNORE_PREFIX          = 
+IGNORE_PREFIX          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output
@@ -1082,7 +1082,7 @@ HTML_FILE_EXTENSION    = .html
 # of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_HEADER            = 
+HTML_HEADER            =
 
 # The HTML_FOOTER tag can be used to specify a user-defined HTML footer for each
 # generated HTML page. If the tag is left blank doxygen will generate a standard
@@ -1092,7 +1092,7 @@ HTML_HEADER            =
 # that doxygen normally uses.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_FOOTER            = 
+HTML_FOOTER            =
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading style
 # sheet that is used by each HTML page. It can be used to fine-tune the look of
@@ -1104,7 +1104,7 @@ HTML_FOOTER            =
 # obsolete.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_STYLESHEET        = 
+HTML_STYLESHEET        =
 
 # The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # cascading style sheets that are included after the standard style sheets
@@ -1127,7 +1127,7 @@ HTML_EXTRA_STYLESHEET  = ../RF24/doxygen-custom.css
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       = 
+HTML_EXTRA_FILES       =
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to
@@ -1256,7 +1256,7 @@ GENERATE_HTMLHELP      = NO
 # written to the html output directory.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-CHM_FILE               = 
+CHM_FILE               =
 
 # The HHC_LOCATION tag can be used to specify the location (absolute path
 # including file name) of the HTML help compiler (hhc.exe). If non-empty,
@@ -1264,7 +1264,7 @@ CHM_FILE               =
 # The file has to be specified with full path.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-HHC_LOCATION           = 
+HHC_LOCATION           =
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated
 # (YES) or that it should be included in the master .chm file (NO).
@@ -1277,7 +1277,7 @@ GENERATE_CHI           = NO
 # and project file content.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
-CHM_INDEX_ENCODING     = 
+CHM_INDEX_ENCODING     =
 
 # The BINARY_TOC flag controls whether a binary table of contents is generated
 # (YES) or a normal table of contents (NO) in the .chm file. Furthermore it
@@ -1308,7 +1308,7 @@ GENERATE_QHP           = NO
 # the HTML output folder.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QCH_FILE               = 
+QCH_FILE               =
 
 # The QHP_NAMESPACE tag specifies the namespace to use when generating Qt Help
 # Project output. For more information please see Qt Help Project / Namespace
@@ -1333,7 +1333,7 @@ QHP_VIRTUAL_FOLDER     = doc
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_CUST_FILTER_NAME   = 
+QHP_CUST_FILTER_NAME   =
 
 # The QHP_CUST_FILTER_ATTRS tag specifies the list of the attributes of the
 # custom filter to add. For more information please see Qt Help Project / Custom
@@ -1341,21 +1341,21 @@ QHP_CUST_FILTER_NAME   =
 # filters).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_CUST_FILTER_ATTRS  = 
+QHP_CUST_FILTER_ATTRS  =
 
 # The QHP_SECT_FILTER_ATTRS tag specifies the list of the attributes this
 # project's filter section matches. Qt Help Project / Filter Attributes (see:
 # http://qt-project.org/doc/qt-4.8/qthelpproject.html#filter-attributes).
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_SECT_FILTER_ATTRS  = 
+QHP_SECT_FILTER_ATTRS  =
 
 # The QHG_LOCATION tag can be used to specify the location of Qt's
 # qhelpgenerator. If non-empty doxygen will try to run qhelpgenerator on the
 # generated .qhp file.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHG_LOCATION           = 
+QHG_LOCATION           =
 
 # If the GENERATE_ECLIPSEHELP tag is set to YES, additional index files will be
 # generated, together with the HTML files, they form an Eclipse help plugin. To
@@ -1488,7 +1488,7 @@ MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_EXTENSIONS     = 
+MATHJAX_EXTENSIONS     =
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with javascript pieces
 # of code that will be used on startup of the MathJax code. See the MathJax site
@@ -1496,7 +1496,7 @@ MATHJAX_EXTENSIONS     =
 # example see the documentation.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_CODEFILE       = 
+MATHJAX_CODEFILE       =
 
 # When the SEARCHENGINE tag is enabled doxygen will generate a search box for
 # the HTML output. The underlying search engine uses javascript and DHTML and
@@ -1556,7 +1556,7 @@ EXTERNAL_SEARCH        = NO
 # Searching" for details.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-SEARCHENGINE_URL       = 
+SEARCHENGINE_URL       =
 
 # When SERVER_BASED_SEARCH and EXTERNAL_SEARCH are both enabled the unindexed
 # search data is written to a file for indexing by an external tool. With the
@@ -1572,7 +1572,7 @@ SEARCHDATA_FILE        = searchdata.xml
 # projects and redirect the results back to the right project.
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-EXTERNAL_SEARCH_ID     = 
+EXTERNAL_SEARCH_ID     =
 
 # The EXTRA_SEARCH_MAPPINGS tag can be used to enable searching through doxygen
 # projects other than the one defined by this configuration file, but that are
@@ -1582,7 +1582,7 @@ EXTERNAL_SEARCH_ID     =
 # EXTRA_SEARCH_MAPPINGS = tagname1=loc1 tagname2=loc2 ...
 # This tag requires that the tag SEARCHENGINE is set to YES.
 
-EXTRA_SEARCH_MAPPINGS  = 
+EXTRA_SEARCH_MAPPINGS  =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the LaTeX output
@@ -1646,7 +1646,7 @@ PAPER_TYPE             = a4wide
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         = 
+EXTRA_PACKAGES         =
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first
@@ -1662,7 +1662,7 @@ EXTRA_PACKAGES         =
 # to HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_HEADER           = 
+LATEX_HEADER           =
 
 # The LATEX_FOOTER tag can be used to specify a personal LaTeX footer for the
 # generated LaTeX document. The footer should contain everything after the last
@@ -1673,7 +1673,7 @@ LATEX_HEADER           =
 # Note: Only use a user-defined footer if you know what you are doing!
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_FOOTER           = 
+LATEX_FOOTER           =
 
 # The LATEX_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # LaTeX style sheets that are included after the standard style sheets created
@@ -1684,7 +1684,7 @@ LATEX_FOOTER           =
 # list).
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_EXTRA_STYLESHEET = 
+LATEX_EXTRA_STYLESHEET =
 
 # The LATEX_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the LATEX_OUTPUT output
@@ -1692,7 +1692,7 @@ LATEX_EXTRA_STYLESHEET =
 # markers available.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_EXTRA_FILES      = 
+LATEX_EXTRA_FILES      =
 
 # If the PDF_HYPERLINKS tag is set to YES, the LaTeX that is generated is
 # prepared for conversion to PDF (using ps2pdf or pdflatex). The PDF file will
@@ -1792,14 +1792,14 @@ RTF_HYPERLINKS         = NO
 # default style sheet that doxygen normally uses.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_STYLESHEET_FILE    = 
+RTF_STYLESHEET_FILE    =
 
 # Set optional variables used in the generation of an RTF document. Syntax is
 # similar to doxygen's config file. A template extensions file can be generated
 # using doxygen -e rtf extensionFile.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_EXTENSIONS_FILE    = 
+RTF_EXTENSIONS_FILE    =
 
 # If the RTF_SOURCE_CODE tag is set to YES then doxygen will include source code
 # with syntax highlighting in the RTF output.
@@ -1844,7 +1844,7 @@ MAN_EXTENSION          = .3
 # MAN_EXTENSION with the initial . removed.
 # This tag requires that the tag GENERATE_MAN is set to YES.
 
-MAN_SUBDIR             = 
+MAN_SUBDIR             =
 
 # If the MAN_LINKS tag is set to YES and doxygen generates man output, then it
 # will generate one additional man file for each entity documented in the real
@@ -1957,7 +1957,7 @@ PERLMOD_PRETTY         = YES
 # overwrite each other's variables.
 # This tag requires that the tag GENERATE_PERLMOD is set to YES.
 
-PERLMOD_MAKEVAR_PREFIX = 
+PERLMOD_MAKEVAR_PREFIX =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor
@@ -1998,7 +1998,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           = 
+INCLUDE_PATH           =
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2006,7 +2006,7 @@ INCLUDE_PATH           =
 # used.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-INCLUDE_FILE_PATTERNS  = 
+INCLUDE_FILE_PATTERNS  =
 
 # The PREDEFINED tag can be used to specify one or more macro names that are
 # defined before the preprocessor is started (similar to the -D option of e.g.
@@ -2016,7 +2016,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = 
+PREDEFINED             =
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2025,7 +2025,7 @@ PREDEFINED             =
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      = 
+EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have
@@ -2054,13 +2054,13 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = 
+TAGFILES               =
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = 
+GENERATE_TAGFILE       =
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be
@@ -2109,14 +2109,14 @@ CLASS_DIAGRAMS         = YES
 # the mscgen tool resides. If left empty the tool is assumed to be found in the
 # default search path.
 
-MSCGEN_PATH            = 
+MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
 # DIA_PATH tag allows you to specify the directory where the dia binary resides.
 # If left empty dia is assumed to be found in the default search path.
 
-DIA_PATH               = 
+DIA_PATH               =
 
 # If set to YES the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.
@@ -2165,7 +2165,7 @@ DOT_FONTSIZE           = 10
 # the path where dot can find it using this tag.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTPATH           = 
+DOT_FONTPATH           =
 
 # If the CLASS_GRAPH tag is set to YES then doxygen will generate a graph for
 # each documented class showing the direct and indirect inheritance relations.
@@ -2309,26 +2309,26 @@ INTERACTIVE_SVG        = NO
 # found. If left blank, it is assumed the dot tool can be found in the path.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_PATH               = 
+DOT_PATH               =
 
 # The DOTFILE_DIRS tag can be used to specify one or more directories that
 # contain dot files that are included in the documentation (see the \dotfile
 # command).
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOTFILE_DIRS           = 
+DOTFILE_DIRS           =
 
 # The MSCFILE_DIRS tag can be used to specify one or more directories that
 # contain msc files that are included in the documentation (see the \mscfile
 # command).
 
-MSCFILE_DIRS           = 
+MSCFILE_DIRS           =
 
 # The DIAFILE_DIRS tag can be used to specify one or more directories that
 # contain dia files that are included in the documentation (see the \diafile
 # command).
 
-DIAFILE_DIRS           = 
+DIAFILE_DIRS           =
 
 # When using plantuml, the PLANTUML_JAR_PATH tag should be used to specify the
 # path where java can find the plantuml.jar file. If left blank, it is assumed
@@ -2336,12 +2336,12 @@ DIAFILE_DIRS           =
 # generate a warning when it encounters a \startuml command in this case and
 # will not generate output for the diagram.
 
-PLANTUML_JAR_PATH      = 
+PLANTUML_JAR_PATH      =
 
 # When using plantuml, the specified paths are searched for files specified by
 # the !include statement in a plantuml block.
 
-PLANTUML_INCLUDE_PATH  = 
+PLANTUML_INCLUDE_PATH  =
 
 # The DOT_GRAPH_MAX_NODES tag can be used to set the maximum number of nodes
 # that will be shown in the graph. If the number of nodes in a graph becomes
@@ -2402,3 +2402,4 @@ GENERATE_LEGEND        = YES
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_CLEANUP            = YES
+

--- a/Doxyfile
+++ b/Doxyfile
@@ -1117,7 +1117,7 @@ HTML_STYLESHEET        =
 # list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  = ../RF24/doxygen-custom.css
+HTML_EXTRA_STYLESHEET  = doxygen-custom.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TMRh20 2014 - Newly Optimized Network Layer for nRF24L01(+) radios
 
-Please see the full documentation at http://tmrh20.github.io/RF24Network/
+Please see the full documentation at http://nRF24.github.io/RF24Network/
 
-See http://tmrh20.github.io/RF24/index.html for general RF24 configuration and setup
-See http://tmrh20.github.io/RF24/Linux.html and http://tmrh20.github.io/RF24/RPi.html for Linux/RPi related config/setup
+See http://nRF24.github.io/RF24/index.html for general RF24 configuration and setup
+See http://nRF24.github.io/RF24/Linux.html and http://nRF24.github.io/RF24/RPi.html for Linux/RPi related config/setup

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -961,7 +961,7 @@ public:
  * @li Network ACKs: Efficient acknowledgement of network-wide transmissions, via dynamic radio acks and network protocol acks.
  * @li Updated addressing standard for optimal radio transmission.
  * @li Extended timeouts and staggered timeout intervals. The new txTimeout variable allows fully automated extended timeout periods via auto-retry/auto-reUse of payloads.
- * @li Optimization to the core library provides improvements to reliability, speed and efficiency. See https://tmrh20.github.io/RF24 for more info.
+ * @li Optimization to the core library provides improvements to reliability, speed and efficiency. See https://nRF24.github.io/RF24 for more info.
  * @li Built in sleep mode using interrupts. (Still under development. (Enable via RF24Network_config.h))
  * @li Host Addressing.  Each node has a logical address on the local network.
  * @li Message Forwarding.  Messages can be sent from one node to any other, and

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -30,7 +30,7 @@
   #include <map>
   #include <utility>      // std::pair
   #include <queue>
-  
+
 //ATXMega
 #elif defined(XMEGA_D3)
   #include "../../rf24lib/rf24lib/RF24.h"
@@ -39,22 +39,22 @@
 
 /**
 
- */  
+ */
 
 /* Header types range */
 #define MIN_USER_DEFINED_HEADER_TYPE 0
 #define MAX_USER_DEFINED_HEADER_TYPE 127
 
-/** 
+/**
 
  */
- 
+
 // ACK Response Types
 /**
  * **Reserved network message types**
  *
  * The network will determine whether to automatically acknowledge payloads based on their general type <br>
- * 
+ *
  * **User types** (1-127) 1-64 will NOT be acknowledged <br>
  * **System types** (128-255) 192 through 255 will NOT be acknowledged<br>
  *
@@ -67,36 +67,36 @@
 
 /**
 * A NETWORK_ADDR_RESPONSE type is utilized to manually route custom messages containing a single RF24Network address
-* 
+*
 * Used by RF24Mesh
-* 
+*
 * If a node receives a message of this type that is directly addressed to it, it will read the included message, and forward the payload
 * on to the proper recipient. <br>
 * This allows nodes to forward multicast messages to the master node, receive a response, and forward it back to the requester.
 */
-#define NETWORK_ADDR_RESPONSE 128 
+#define NETWORK_ADDR_RESPONSE 128
 
 /**
-* Messages of type NETWORK_PING will be dropped automatically by the recipient. A NETWORK_ACK or automatic radio-ack will indicate to the sender whether the 
+* Messages of type NETWORK_PING will be dropped automatically by the recipient. A NETWORK_ACK or automatic radio-ack will indicate to the sender whether the
 * payload was successful. The time it takes to successfully send a NETWORK_PING is the round-trip-time.
 */
 #define NETWORK_PING 130
 
 /**
- * External data types are used to define messages that will be passed to an external data system. This allows RF24Network to route and pass any type of data, such 
+ * External data types are used to define messages that will be passed to an external data system. This allows RF24Network to route and pass any type of data, such
  * as TCP/IP frames, while still being able to utilize standard RF24Network messages etc.
  *
  * **Linux**
- * Linux devices (defined RF24_LINUX) will buffer all data types in the user cache. 
+ * Linux devices (defined RF24_LINUX) will buffer all data types in the user cache.
  *
  * **Arduino/AVR/Etc:** Data transmitted with the type set to EXTERNAL_DATA_TYPE will not be loaded into the user cache. <br>
  * External systems can extract external data using the following process, while internal data types are cached in the user buffer, and accessed using network.read() :
  * @code
  * uint8_t return_type = network.update();
  * if(return_type == EXTERNAL_DATA_TYPE){
- *     uint16_t size = network.frag_ptr->message_size;	
+ *     uint16_t size = network.frag_ptr->message_size;
  *     memcpy(&myDataBuffer,network.frag_ptr->message_buffer,network.frag_ptr->message_size);
- * }		
+ * }
  * @endcode
  */
 #define EXTERNAL_DATA_TYPE 131
@@ -115,7 +115,7 @@
  * Messages of this type indicate the last fragment in a sequence of message fragments.
  * Messages of this type do not receive a NETWORK_ACK
  */
-#define NETWORK_LAST_FRAGMENT 150 
+#define NETWORK_LAST_FRAGMENT 150
 //#define NETWORK_LAST_FRAGMENT 201
 
 // NO ACK Response Types
@@ -125,9 +125,9 @@
  * Messages of this type are used internally, to signal the sender that a transmission has been completed.
  * RF24Network does not directly have a built-in transport layer protocol, so message delivery is not 100% guaranteed.<br>
  * Messages can be lost via corrupted dynamic payloads, or a NETWORK_ACK can fail, while the message was actually successful.
- * 
+ *
  * NETWORK_ACK messages can be utilized as a traffic/flow control mechanism, since transmitting nodes will be forced to wait until
- * the payload is transmitted across the network and acknowledged, before sending additional data. 
+ * the payload is transmitted across the network and acknowledged, before sending additional data.
  *
  * In the event that the transmitting device will be waiting for a direct response, manually sent by the recipient, a NETWORK_ACK is not required. <br>
  * User messages utilizing a 'type' with a decimal value of 64 or less will not be acknowledged across the network via NETWORK_ACK messages.
@@ -140,7 +140,7 @@
  * Messages of this type are used with multi-casting , to find active/available nodes.
  * Any node receiving a NETWORK_POLL sent to a multicast address will respond directly to the sender with a blank message, indicating the
  * address of the available node via the header.
- */ 
+ */
 #define NETWORK_POLL 194
 
 /**
@@ -199,12 +199,12 @@ struct RF24NetworkHeader
    uint16_t id; /**< Sequential message ID, incremented every time a new frame is constructed */
    /**
    * Message Types:
-   * User message types 1 through 64 will NOT be acknowledged by the network, while message types 65 through 127 will receive a network ACK.  
+   * User message types 1 through 64 will NOT be acknowledged by the network, while message types 65 through 127 will receive a network ACK.
    * System message types 192 through 255 will NOT be acknowledged by the network. Message types 128 through 192 will receive a network ACK. <br>
    * <br><br>
    */
    unsigned char type; /**< <b>Type of the packet. </b> 0-127 are user-defined types, 128-255 are reserved for system */
-  
+
    /**
    * During fragmentation, it carries the fragment_id, and on the last fragment
    * it carries the header_type.<br>
@@ -222,20 +222,20 @@ struct RF24NetworkHeader
    RF24NetworkHeader() {}
 
    /**
-   * Send constructor  
-   *  
-   * @note Now supports automatic fragmentation for very long messages, which can be sent as usual if fragmentation is enabled. 
+   * Send constructor
+   *
+   * @note Now supports automatic fragmentation for very long messages, which can be sent as usual if fragmentation is enabled.
    *
    * Fragmentation is enabled by default for all devices except ATTiny <br>
    * Configure fragmentation and max payload size in RF24Network_config.h
-   *  
-   * Use this constructor to create a header and then send a message  
-   *   
+   *
+   * Use this constructor to create a header and then send a message
+   *
    * @code
    *  uint16_t recipient_address = 011;
-   *  
+   *
    *  RF24NetworkHeader header(recipient_address,'t');
-   *  
+   *
    *  network.write(header,&message,sizeof(message));
    * @endcode
    *
@@ -263,10 +263,10 @@ struct RF24NetworkHeader
  *
  * The actual frame put over the air consists of a header (8-bytes) and a message payload (Up to 24-bytes)<br>
  * When data is received, it is stored using the RF24NetworkFrame structure, which includes:
- * 1. The header 
- * 2. The size of the included message 
+ * 1. The header
+ * 2. The size of the included message
  * 3. The 'message' or data being received
- * 
+ *
  *
  */
 
@@ -275,22 +275,22 @@ struct RF24NetworkHeader
 {
    RF24NetworkHeader header; /**< Header which is sent with each message */
    uint16_t message_size; /**< The size in bytes of the payload length */
-  
+
    /**
    * On Arduino, the message buffer is just a pointer, and can be pointed to any memory location.
    * On Linux the message buffer is a standard byte array, equal in size to the defined MAX_PAYLOAD_SIZE
    */
    #if defined (RF24_LINUX)
      uint8_t message_buffer[MAX_PAYLOAD_SIZE]; //< Array to store the message
-   #else    
-     uint8_t *message_buffer; //< Pointer to the buffer storing the actual message 
+   #else
+     uint8_t *message_buffer; //< Pointer to the buffer storing the actual message
    #endif
 
    /**
    * Default constructor
    *
    * Simply constructs a blank frame. Frames are generally used internally. See RF24NetworkHeader.
-   */  
+   */
    RF24NetworkFrame() {}
 
    /**
@@ -308,22 +308,22 @@ struct RF24NetworkHeader
    * @see RF24Network.frag_ptr
    * @param _header The RF24Network header to be stored in the frame
    * @param _message_size The size of the 'message' or data
-   * 
+   *
    *
    * Frames are used internally and by external systems. See RF24NetworkHeader.
    */
-   #if defined (RF24_LINUX)   
+   #if defined (RF24_LINUX)
      RF24NetworkFrame(RF24NetworkHeader& _header, const void* _message = NULL, uint16_t _len = 0) :
        header(_header), message_size(_len) {
        if (_message && _len) {
          memcpy(message_buffer,_message,_len);
        }
      }
-   #else  
+   #else
      RF24NetworkFrame(RF24NetworkHeader &_header, uint16_t _message_size):
-       header(_header), message_size(_message_size){		  
+       header(_header), message_size(_message_size){
      }
-   #endif  
+   #endif
 
 
    /**
@@ -339,7 +339,7 @@ struct RF24NetworkHeader
 
 };
 
- 
+
 
 /**
  * 2014-2020 - Optimized Network Layer for RF24 Radios
@@ -351,14 +351,13 @@ struct RF24NetworkHeader
 class RF24Network
 {
 
-   /**@}*/
    /**
    * @name Primary Interface
    *
    *  These are the main methods you need to operate the network
    */
    /**@{*/
-  
+
 public:
    /**
    * Construct the network
@@ -386,12 +385,12 @@ public:
    * **Example 3:** Begin with address 011 (child of 01, grandchild of master)
    * @code
    * network.begin(011);
-   * @endcode   
+   * @endcode
    *
    * @see begin(uint8_t _channel, uint16_t _node_address )
    * @param _node_address The logical address of this node
    *
-   */ 
+   */
    inline void begin(uint16_t _node_address){
      begin(USE_CURRENT_CHANNEL,_node_address);
    }
@@ -399,11 +398,11 @@ public:
    /**
    * Main layer loop
    *
-   * This function must be called regularly to keep the layer going.  This is where payloads are 
+   * This function must be called regularly to keep the layer going.  This is where payloads are
    * re-routed, received, and all the action happens.
    *
    * @see
-   * 
+   *
    * @return Returns the type of the last received payload.
    */
    uint8_t update(void);
@@ -431,7 +430,7 @@ public:
    * Read the next available payload
    *
    * Reads the next available payload without advancing to the next
-   * incoming message.  Useful for doing a transparent packet 
+   * incoming message.  Useful for doing a transparent packet
    * manipulation layer on top of RF24Network.
    *
    * @param[out] header The header (envelope) of this message
@@ -467,7 +466,7 @@ public:
    *
    * @note RF24Network now supports fragmentation for very long messages, send as normal. Fragmentation
    * may need to be enabled or configured by editing the RF24Network_config.h file. Default max payload size is 120 bytes.
-   * 
+   *
    * @code
    * uint32_t time = millis();
    * uint16_t to = 00; // Send to master
@@ -490,7 +489,7 @@ public:
    *  For advanced configuration of the network
    */
    /**@{*/
-  
+
 
    /**
    * Construct the network in dual head mode using two radio modules.
@@ -503,16 +502,16 @@ public:
    * @param _radio The underlying radio driver instance
    * @param _radio1 The second underlying radio driver instance
    */
-   
-   RF24Network( RF24& _radio, RF24& _radio1); 
-  
+
+   RF24Network( RF24& _radio, RF24& _radio1);
+
    /**
-   * By default, multicast addresses are divided into levels. 
+   * By default, multicast addresses are divided into levels.
    *
    * Nodes 1-5 share a multicast address, nodes n1-n5 share a multicast address, and nodes n11-n55 share a multicast address.<br>
    *
    * This option is used to override the defaults, and create custom multicast groups that all share a single
-   * address. <br> 
+   * address. <br>
    * The level should be specified in decimal format 1-6 <br>
    * @see multicastRelay
    * @param level Levels 1 to 6 are available. All nodes at the same level will receive the same
@@ -528,7 +527,7 @@ public:
    * not interfere. Forwarded payloads will also be received.
    * @see multicastLevel
    */
-	
+
    bool multicastRelay;
 
    /**
@@ -552,17 +551,17 @@ public:
    */
 
    uint32_t txTimeout; /**< Network timeout value */
-  
+
    /**
    * This only affects payloads that are routed by one or more nodes.
    * This specifies how long to wait for an ack from across the network.
    * Radios sending directly to their parent or children nodes do not
    * utilize this value.
    */
-  
-   uint16_t routeTimeout; /**< Timeout for routed payloads */  
-  
- 
+
+   uint16_t routeTimeout; /**< Timeout for routed payloads */
+
+
    /**@}*/
    /**
    * @name Advanced Operation
@@ -572,38 +571,39 @@ public:
    /**@{*/
 
    /**
-   * Return the number of failures and successes for all transmitted payloads, routed or sent directly  
-   * @note This needs to be enabled via #define ENABLE_NETWORK_STATS in RF24Network_config.h
+   * Return the number of failures and successes for all transmitted payloads, routed or sent directly
+   * @note This needs to be enabled via `#define ENABLE_NETWORK_STATS` in RF24Network_config.h
    *
-   *   @code  
-   * bool fails, success;  
-   * network.failures(&fails,&success);  
-   * @endcode  
+   *   @code
+   * bool fails, success;
+   * network.failures(&fails,&success);
+   * @endcode
    *
    */
    void failures(uint32_t *_fails, uint32_t *_ok);
-  
+
    #if defined (RF24NetworkMulticast)
-  
+
   /**
    * Send a multicast message to multiple nodes at once
-   * Allows messages to be rapidly broadcast through the network  
-   *   
-   * Multicasting is arranged in levels, with all nodes on the same level listening to the same address  
+   * Allows messages to be rapidly broadcast through the network
+   *
+   * Multicasting is arranged in levels, with all nodes on the same level listening to the same address
    * Levels are assigned by network level ie: nodes 01-05: Level 1, nodes 011-055: Level 2
    * @see multicastLevel
    * @see multicastRelay
+   * @param header reference to the RF24NetworkHeader object used for this @p message
    * @param message Pointer to memory where the message is located
    * @param len The size of the message
    * @param level Multicast level to broadcast to
    * @return Whether the message was successfully sent
    */
-   
-   bool multicast(RF24NetworkHeader& header,const void* message, uint16_t len, uint8_t level);
-   
-	
+
+   bool multicast(RF24NetworkHeader& header, const void* message, uint16_t len, uint8_t level);
+
+
    #endif
-   
+
    /**
    * Writes a direct (unicast) payload. This allows routing or sending messages outside of the usual routing paths.
    * The same as write, but a physical address is specified as the last option.
@@ -614,7 +614,7 @@ public:
    /**
    * Sleep this node - For AVR devices only
    * @note NEW - Nodes can now be slept while the radio is not actively transmitting. This must be manually enabled by uncommenting
-   * the #define ENABLE_SLEEP_MODE in RF24Network_config.h
+   * the `#define ENABLE_SLEEP_MODE` in RF24Network_config.h
    * @note Setting the interruptPin to 255 will disable interrupt wake-ups
    * @note The watchdog timer should be configured in setup() if using sleep mode.
    * This function will sleep the node, with the radio still active in receive mode.
@@ -632,6 +632,13 @@ public:
    * @see setup_watchdog()
    * @param cycles: The node will sleep in cycles of 1s. Using 2 will sleep 2 WDT cycles, 3 sleeps 3WDT cycles...
    * @param interruptPin: The interrupt number to use (0,1) for pins two and three on Uno,Nano. More available on Mega etc.
+   * @param INTERRUPT_MODE an identifying number to indicate what type of state for which the @p interrupt_pin will be used to wake up the radio.
+   * | @p INTERRUPT_MODE | type of state |
+   * |:-----------------:|:-------------:|
+   * | 0 | LOW      |
+   * | 1 | RISING   |
+   * | 2 | FALLING  |
+   * | 3 | CHANGE   |
    * @return True if sleepNode completed normally, after the specified number of cycles. False if sleep was interrupted
    */
    bool sleepNode( unsigned int cycles, int interruptPin, uint8_t INTERRUPT_MODE=0); //added interrupt mode support (default 0=LOW)
@@ -643,12 +650,12 @@ public:
    * @return This node's parent address, or -1 if this is the base
    */
    uint16_t parent() const;
-  
+
    /**
    * Provided a node address and a pipe number, will return the RF24Network address of that child pipe for that node
    */
    uint16_t addressOfPipe( uint16_t node,uint8_t pipeNo );
-   
+
    /**
    * @note Addresses are specified in octal: 011, 034
    * @return True if a supplied address is valid
@@ -661,8 +668,8 @@ public:
    *
    *  Maintained for backwards compatibility
    */
-  /**@{*/  
-  
+  /**@{*/
+
   /**
    * Bring up the network on a specific radio frequency/channel.
    * @note Use radio.setChannel() to configure the radio channel
@@ -678,14 +685,14 @@ public:
    * **Example 3:** Begin on channel 90 with address 011 (child of 01, grandchild of master)
    * @code
    * network.begin(90,011);
-   * @endcode   
+   * @endcode
    *
    * @param _channel The RF channel to operate on
    * @param _node_address The logical address of this node
    *
    */
-  void begin(uint8_t _channel, uint16_t _node_address );  
-  
+  void begin(uint8_t _channel, uint16_t _node_address );
+
   /**@}*/
   /**
    * @name External Applications/Systems
@@ -693,12 +700,12 @@ public:
    *  Interface for External Applications and Systems ( RF24Mesh, RF24Ethernet )
    */
   /**@{*/
-  
-  /** The raw system frame buffer of received data. */
-  
-  uint8_t frame_buffer[MAX_FRAME_SIZE];   
 
-  /** 
+  /** The raw system frame buffer of received data. */
+
+  uint8_t frame_buffer[MAX_FRAME_SIZE];
+
+  /**
    * **Linux** <br>
    * Data with a header type of EXTERNAL_DATA_TYPE will be loaded into a separate queue.
    * The data can be accessed as follows:
@@ -716,7 +723,7 @@ public:
   #if defined (RF24_LINUX)
     std::queue<RF24NetworkFrame> external_queue;
   #endif
-  
+
   #if !defined ( DISABLE_FRAGMENTATION ) &&  !defined (RF24_LINUX)
   /**
   * **ARDUINO** <br>
@@ -724,25 +731,25 @@ public:
   * an EXTERNAL_DATA payload type is received, and returned from network.update(), the frag_ptr will always point to the starting
   * memory location of the received frame. <br>This is used by external data systems (RF24Ethernet) to immediately copy the received
   * data to a buffer, without using the user-cache.
-  * 
+  *
   * @see RF24NetworkFrame
-  * 
+  *
  * @code
  * uint8_t return_type = network.update();
  * if(return_type == EXTERNAL_DATA_TYPE){
- *     uint16_t size = network.frag_ptr->message_size;	
+ *     uint16_t size = network.frag_ptr->message_size;
  *     memcpy(&myDataBuffer,network.frag_ptr->message_buffer,network.frag_ptr->message_size);
- * }		
- * @endcode  
-  * Linux devices (defined as RF24_LINUX) currently cache all payload types, and do not utilize frag_ptr. 
+ * }
+ * @endcode
+  * Linux devices (defined as RF24_LINUX) currently cache all payload types, and do not utilize frag_ptr.
   */
   RF24NetworkFrame* frag_ptr;
   #endif
 
   /**
   * Variable to determine whether update() will return after the radio buffers have been emptied (DEFAULT), or
-  * whether to return immediately when (most) system types are received. 
-  * 
+  * whether to return immediately when (most) system types are received.
+  *
   * As an example, this is used with RF24Mesh to catch and handle system messages without loading them into the user cache.
   *
   * The following reserved/system message types are handled automatically, and not returned.
@@ -753,9 +760,9 @@ public:
   * | NETWORK_ACK           |
   * | NETWORK_PING          |
   * | NETWORK_POLL <br>(With multicast enabled) |
-  * | NETWORK_REQ_ADDRESS   |  
+  * | NETWORK_REQ_ADDRESS   |
   *
-  */  
+  */
   bool returnSysMsgs;
 
   /**
@@ -763,17 +770,17 @@ public:
   *
   * Incoming Blocking: If the network user-cache is full, lets radio cache fill up. Radio ACKs are not sent when radio internal cache is full.<br>
   * This behaviour may seem to result in more failed sends, but the payloads would have otherwise been dropped due to the cache being full.<br>
-  * 
+  *
   * | FLAGS | Value | Description |
   * |-------|-------|-------------|
   * |FLAG_HOLD_INCOMING| 1(bit_1) | INTERNAL: Set automatically when a fragmented payload will exceed the available cache |
   * |FLAG_BYPASS_HOLDS| 2(bit_2) | EXTERNAL: Can be used to prevent holds from blocking. Note: Holds are disabled & re-enabled by RF24Mesh when renewing addresses. This will cause data loss if incoming data exceeds the available cache space|
   * |FLAG_FAST_FRAG| 4(bit_3) | INTERNAL: Replaces the fastFragTransfer variable, and allows for faster transfers between directly connected nodes. |
-  * |FLAG_NO_POLL| 8(bit_4) | EXTERNAL/USER: Disables NETWORK_POLL responses on a node-by-node basis. |  
-  * 
+  * |FLAG_NO_POLL| 8(bit_4) | EXTERNAL/USER: Disables NETWORK_POLL responses on a node-by-node basis. |
+  *
   */
   uint8_t networkFlags;
-    
+
   private:
 
   bool write(uint16_t, uint8_t directTo);
@@ -782,26 +789,26 @@ public:
 
   bool is_direct_child( uint16_t node );
   bool is_descendant( uint16_t node );
-  
+
   uint16_t direct_child_route_to( uint16_t node );
   void setup_address(void);
   bool _write(RF24NetworkHeader& header,const void* message, uint16_t len, uint16_t writeDirect);
-    
+
   struct logicalToPhysicalStruct{
-	uint16_t send_node; 
+	uint16_t send_node;
 	uint8_t send_pipe;
 	bool multicast;
   };
-  
+
   void logicalToPhysicalAddress(logicalToPhysicalStruct *conversionInfo);
-  
-  
+
+
   RF24& radio; /**< Underlying radio driver, provides link/physical layers */
 #if defined (DUAL_HEAD_RADIO)
   RF24& radio1;
 #endif
-#if defined (RF24NetworkMulticast)  
-  uint8_t multicast_level;  
+#if defined (RF24NetworkMulticast)
+  uint8_t multicast_level;
 #endif
   uint16_t node_address; /**< Logical node address of this unit, 1 .. UINT_MAX */
   uint8_t frame_size;
@@ -811,7 +818,7 @@ public:
     std::queue<RF24NetworkFrame> frame_queue;
 	std::map< uint16_t, RF24NetworkFrame> frameFragmentsCache;
     bool appendFragmentToFrame(RF24NetworkFrame frame);
-  
+
   #else // Not Linux:
 
 	#if defined (DISABLE_USER_PAYLOADS)
@@ -819,33 +826,34 @@ public:
 	#else
 	uint8_t frame_queue[MAIN_BUFFER_SIZE]; /**< Space for a small set of frames that need to be delivered to the app layer */
 	#endif
-	
+
 	uint8_t* next_frame; /**< Pointer into the @p frame_queue where we should place the next received frame */
-	
+
 	#if !defined ( DISABLE_FRAGMENTATION )
       RF24NetworkFrame frag_queue;
-      uint8_t frag_queue_message_buffer[MAX_PAYLOAD_SIZE]; //frame size + 1 
+      uint8_t frag_queue_message_buffer[MAX_PAYLOAD_SIZE]; //frame size + 1
     #endif
-  
+
   #endif // Linux/Not Linux
-  
+
   uint16_t parent_node; /**< Our parent's node address */
   uint8_t parent_pipe; /**< The pipe our parent uses to listen to us */
   uint16_t node_mask; /**< The bits which contain signfificant node address information */
   uint64_t pipe_address( uint16_t node, uint8_t pipe );
-  
+
   #if defined ENABLE_NETWORK_STATS
   uint32_t nFails;
   uint32_t nOK;
   #endif
-  
+
   #if defined (RF24NetworkMulticast)
   uint16_t levelToAddress( uint8_t level );
   #endif
-  
+
+/** @} */
 public:
 
-   
+
 
 };
 
@@ -871,8 +879,8 @@ public:
  * A more advanced version of helloworld_tx using fragmentation/reassembly
  * and variable payload sizes
  */
- 
- /**
+
+/**
  * @example helloworld_rx_advanced.ino
  * A more advanced version of helloworld_rx using fragmentation/reassembly
  * and variable payload sizes
@@ -920,14 +928,6 @@ public:
  */
 
 /**
- * @example sensornet.pde
- *
- * Example of a sensor network.
- * This sketch demonstrates how to use the RF24Network library to
- * manage a set of low-power sensor nodes which mostly sleep but
- * awake regularly to send readings to the base.
- */
-/**
  * @mainpage Network Layer for RF24 Radios
  *
  * This class implements an <a href="http://en.wikipedia.org/wiki/Network_layer">OSI Network Layer</a> using nRF24L01(+) radios driven
@@ -936,7 +936,7 @@ public:
  * @section Purpose Purpose/Goal
  *
  * Original: Create an alternative to ZigBee radios for Arduino communication.
- * 
+ *
  * New: Enhance the current functionality for maximum efficiency, reliability, and speed
  *
  * Xbees are excellent little radios, backed up by a mature and robust standard
@@ -982,16 +982,16 @@ public:
  * @li <a href="https://github.com/TMRh20/RF24Network/archive/Development.zip">Download Current Development Package</a>
  * @li <a href="examples.html">Examples Page</a>.  Start with <a href="helloworld_rx_8ino-example.html">helloworld_rx</a> and <a href="helloworld_tx_8ino-example.html">helloworld_tx</a>.
  *
- * <b> Additional Information & Add-ons </b>  
+ * <b> Additional Information & Add-ons </b>
  * @li <a href="https://github.com/TMRh20/RF24Mesh">RF24Mesh: Dynamic Mesh Layer for RF24Network Dev</a>
  * @li <a href="https://github.com/TMRh20/RF24Ethernet">RF24Ethernet: TCP/IP over RF24Network</a>
  * @li <a href="http://tmrh20.blogspot.com/2014/03/high-speed-data-transfers-and-wireless.html">My Blog: RF24 Optimization Overview</a>
  * @li <a href="http://tmrh20.blogspot.com/2014/03/arduino-radiointercomwireless-audio.html">My Blog: RF24 Wireless Audio</a>
  * @li <a href="http://maniacbug.github.com/RF24/">RF24: Original Author</a>
- * @section Topology Topology for Mesh Networks using nRF24L01(+)
+ * @section MeshTopology Topology for Mesh Networks using nRF24L01(+)
  *
  * This network layer takes advantage of the fundamental capability of the nRF24L01(+) radio to
- * listen actively to up to 6 other radios at once.  The network is arranged in a
+ * listen actively to up to 6 other radios at once. The network is arranged in a
  * <a href="http://en.wikipedia.org/wiki/Network_Topology#Tree">Tree Topology</a>, where
  * one node is the base, and all other nodes are children either of that node, or of another.
  * Unlike a true mesh network, multiple nodes are not connected together, so there is only one
@@ -1054,25 +1054,25 @@ public:
  *
  * @section Overview Overview
  * The nrf24 radio modules typically use a 40-bit address format, requiring 5-bytes of storage space per address, and allowing a wide
- * array of addresses to be utilized. In addition, the radios are limited to direct communication with 6 other nodes while using the 
- * Enhanced-Shock-Burst (ESB) functionality of the radios.  
+ * array of addresses to be utilized. In addition, the radios are limited to direct communication with 6 other nodes while using the
+ * Enhanced-Shock-Burst (ESB) functionality of the radios.
  *
  * RF24Network uses a simple method of data compression to store the addresses using only 2 bytes, in a format designed to represent the
  * network topology in an intuitive way.
  * See the <a href="Tuning.html"> Topology and Overview</a> page for more info regarding topology.
  *
  * @section Octal_Binary Decimal, Octal and Binary formats
- * 
+ *
  * Say we want to designate a logical address to a node, using a tree topology as defined by the manufacturer.
- * In the simplest format, we could assign the first node the address of 1, the second 2 and so on.  
+ * In the simplest format, we could assign the first node the address of 1, the second 2 and so on.
  * Since a single node can only connect to 6 other nodes (1 parent and 5 children) subnets need to be created if using more than 6 nodes.<br>
  * In this case the children of node 1 could simply be designated as 11,21,31,41, and 51<br>
- * Children of node 2 could be designated as 12,22,32,42, and 52  
- * 
+ * Children of node 2 could be designated as 12,22,32,42, and 52
+ *
  * The above example is exactly how RF24Network manages the addresses, but they are represented in Octal format.
- * 
- * <b>Decimal, Octal and Binary</b>  
- * <table> 
+ *
+ * <b>Decimal, Octal and Binary</b>
+ * <table>
  * <tr bgcolor="#a3b4d7" >
  * <td> Decimal </td> <td> Binary </td><td> Decimal </td> <td> Binary </td><td> Decimal </td> <td> Binary </td>
  * </tr><tr>
@@ -1084,15 +1084,15 @@ public:
  * </tr>
  * </table>
  *
- *  
- * Since the numbers 0-7 can be represented in exactly three bits, each digit is represented by exactly 3 bits when viewed in octal format.  
- * This allows a very simple method of managing addresses via masking and bit shifting.  
- *   
+ *
+ * Since the numbers 0-7 can be represented in exactly three bits, each digit is represented by exactly 3 bits when viewed in octal format.
+ * This allows a very simple method of managing addresses via masking and bit shifting.
+ *
  * @section DisplayAddresses Displaying Addresses
  *
  * When using Arduino devices, octal addresses can be printed in the following manner:
  * @code
- * uint16_t address = 0111; 
+ * uint16_t address = 0111;
  * Serial.println(address,OCT);
  * @endcode
  *
@@ -1103,7 +1103,7 @@ public:
  * @endcode
  *
  * See http://www.cplusplus.com/doc/hex/ for more information<br>
- * See the <a href="Tuning.html"> Topology and Overview</a> page for more info regarding topology.  
+ * See the <a href="Tuning.html"> Topology and Overview</a> page for more info regarding topology.
  *
  * @page AdvancedConfig Advanced Configuration
  *
@@ -1111,12 +1111,12 @@ public:
  *
  * | Configuration Option | Description |
  * |----------------------|-------------|
- * |<b> #define RF24NetworkMulticast </b> | This option allows nodes to send and receive multicast payloads. Nodes with multicast enabled can also be configured to relay multicast payloads on to further multicast levels. See multicastRelay |
- * | <b> #define DISABLE_FRAGMENTATION </b> | Fragmentation is enabled by default, and uses an additional 144 bytes of memory. |
- * | <b> #define MAX_PAYLOAD_SIZE 144 </b> | The maximum size of payloads defaults to 144 bytes. If used with RF24toTUN and two Raspberry Pi, set this to 1500 |
- * | <b> #define DISABLE_USER_PAYLOADS </b> | This option will disable user-caching of payloads entirely. Use with RF24Ethernet to reduce memory usage. (TCP/IP is an external data type, and not cached) |
- * | <b> #define ENABLE_SLEEP_MODE </b> | Uncomment this option to enable sleep mode for AVR devices. (ATTiny,Uno, etc) |
- * | **#define ENABLE_NETWORK_STATS** | Enable counting of all successful or failed transmissions, routed or sent directly |
+ * | `#define RF24NetworkMulticast` | This option allows nodes to send and receive multicast payloads.<br>Nodes with multicast enabled can also be configured to relay multicast payloads on to further multicast levels.<br>See RF24Network::multicastRelay |
+ * | `#define DISABLE_FRAGMENTATION` | Fragmentation is enabled by default, and uses an additional 144 bytes of memory. |
+ * | `#define MAX_PAYLOAD_SIZE 144` | The maximum size of payloads defaults to 144 bytes. If used with RF24toTUN and two Raspberry Pi, set this to 1500 |
+ * | `#define DISABLE_USER_PAYLOADS` | This option will disable user-caching of payloads entirely. Use with RF24Ethernet to reduce memory usage. (TCP/IP is an external data type, and not cached) |
+ * | `#define ENABLE_SLEEP_MODE` | Uncomment this option to enable sleep mode for AVR devices. (ATTiny,Uno, etc) |
+ * | `#define ENABLE_NETWORK_STATS` | Enable counting of all successful or failed transmissions, routed or sent directly |
  *
  ** @page Tuning Performance and Data Loss: Tuning the Network
  * Tips and examples for tuning the network and general operation.
@@ -1126,12 +1126,12 @@ public:
  * @section General Understanding Radio Communication and Topology
  * When a transmission takes place from one radio module to another, the receiving radio will communicate
  * back to the sender with an acknowledgement (ACK) packet, to indicate success. If the sender does not
- * receive an ACK, the radio automatically engages in a series of timed retries, at set intervals. The 
- * radios use techniques like addressing and numbering of payloads to manage this, but it is all done 
+ * receive an ACK, the radio automatically engages in a series of timed retries, at set intervals. The
+ * radios use techniques like addressing and numbering of payloads to manage this, but it is all done
  * automatically by the nrf chip, out of sight from the user.
  *
  * When working over a radio network, some of these automated techniques can actually hinder data transmission to a degree.
- * Retrying failed payloads over and over on a radio network can hinder communication for nearby nodes, or 
+ * Retrying failed payloads over and over on a radio network can hinder communication for nearby nodes, or
  * reduce throughput and errors on routing nodes.
  *
  * Radios in this network are linked by <b>addresses</b> assigned to <b>pipes</b>. Each radio can listen
@@ -1146,16 +1146,16 @@ public:
  * subnet below it, with up to 4 additional child nodes. The numbering scheme can also be related to IP addresses,
  * for purposes of understanding the topology via subnetting. Nodes can have 5 children if multicast is disabled.
  *
- * Expressing RF24Network addresses in IP format:  
+ * Expressing RF24Network addresses in IP format:
  *
- * As an example, we could designate the master node in theory, as Address 10.10.10.10 <br> 
- * The children nodes of the master would be 10.10.10.1, 10.10.10.2, 10.10.10.3, 10.10.10.4 and 10.10.10.5 <br> 
- * The children nodes of 10.10.10.1 would be 10.10.1.1, 10.10.2.1, 10.10.3.1, 10.10.4.1 and 10.10.5.1 <br> 
- *    
+ * As an example, we could designate the master node in theory, as Address 10.10.10.10 <br>
+ * The children nodes of the master would be 10.10.10.1, 10.10.10.2, 10.10.10.3, 10.10.10.4 and 10.10.10.5 <br>
+ * The children nodes of 10.10.10.1 would be 10.10.1.1, 10.10.2.1, 10.10.3.1, 10.10.4.1 and 10.10.5.1 <br>
+ *
  * In RF24Network, the master is just 00  <br>
  * Children of master are 01,02,03,04,05  <br>
  * Children of 01 are 011,021,031,041,051  <br>
- * 
+ *
  * @section Network Routing
  *
  * Routing of traffic is handled invisibly to the user, by the network layer. If the network addresses are
@@ -1177,8 +1177,8 @@ public:
  *
  * Old Functionality: Node 00 sends to node 011 using auto-ack. Node 00 first sends to 01, 01 acknowledges.
  * Node 01 forwards the payload to 011 using auto-ack. If the payload fails between 01 and 011, node 00 has
- * no way of knowing. 
- * 
+ * no way of knowing.
+ *
  * @note When retrying failed payloads that have been routed, there is a chance of duplicate payloads if the network-ack
  * is not successful. In this case, it is left up to the user to manage retries and filtering of duplicate payloads.
  *
@@ -1186,7 +1186,7 @@ public:
  * an acknowledgement is not required, so a user defined type of 0-64 should be used, to prevent the network from
  * responding with an acknowledgement. If not requesting a response, and wanting to know if the payload was successful
  * or not, users can utilize header types 65-127.
- * 
+ *
  * @section TuningOverview Tuning Overview
  * The RF24 radio modules are generally only capable of either sending or receiving data at any given
  * time, but have built-in auto-retry mechanisms to prevent the loss of data. These values are adjusted
@@ -1288,7 +1288,7 @@ public:
  * @li Base node.  The top of the tree node with no parents, only children.  Typically this node
  * will bridge to another kind of network like Ethernet.  ZigBee calls it a Co-ordinator node.
  *
- * 
+ *
  *
  *
  */

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -21,20 +21,21 @@
     //#define ENABLE_SLEEP_MODE  //AVR only
     #define RF24NetworkMulticast
 
-    /** \def
-	 * Saves memory by disabling fragmentation
-	 */
-    //#define DISABLE_FRAGMENTATION 
+    /* *
+     * \def
+	   * Saves memory by disabling fragmentation
+	   */
+    //#define DISABLE_FRAGMENTATION
 
     /** System defines */
 
-    /** Maximum size of fragmented network frames and fragmentation cache. 
-    *
-    * @note: This buffer can now be any size > 24. Previously need to be a multiple of 24.
-    * @note: If used with RF24Ethernet, this value is used to set the buffer sizes.
-    */
+    /** Maximum size of fragmented network frames and fragmentation cache.
+     *
+     * @note: This buffer can now be any size > 24. Previously need to be a multiple of 24.
+     * @note: If used with RF24Ethernet, this value is used to set the buffer sizes.
+     */
     #define MAX_PAYLOAD_SIZE  144
-    
+
     /** The size of the main buffer. This is the user-cache, where incoming data is stored.
      * Data is stored using Frames: Header (8-bytes) + Frame_Size (2-bytes) + Data (?-bytes)
      */
@@ -42,11 +43,11 @@
 
 
     /** Disable user payloads. Saves memory when used with RF24Ethernet or software that uses external data.*/
-    //#define DISABLE_USER_PAYLOADS 
+    //#define DISABLE_USER_PAYLOADS
 
     /** Enable tracking of success and failures for all transmissions, routed and user initiated */
     //#define ENABLE_NETWORK_STATS
-    
+
     /** Enable dynamic payloads - If using different types of NRF24L01 modules, some may be incompatible when using this feature **/
     #define ENABLE_DYNAMIC_PAYLOADS
 
@@ -57,7 +58,7 @@
     //#define SERIAL_DEBUG_FRAGMENTATION
     //#define SERIAL_DEBUG_FRAGMENTATION_L2
     /*************************************/
- 
+
   #else // Different set of defaults for ATTiny - fragmentation is disabled and user payloads are set to 3 max
     /********** USER CONFIG - ATTiny **************/
     //#define DUAL_HEAD_RADIO
@@ -69,7 +70,7 @@
     // Enable MAX PAYLOAD SIZE if enabling fragmentation
     //#define MAX_PAYLOAD_SIZE  MAIN_BUFFER_SIZE-10
     #define ENABLE_DYNAMIC_PAYLOADS
-    //#define DISABLE_USER_PAYLOADS 
+    //#define DISABLE_USER_PAYLOADS
   #endif
   /*************************************/
 
@@ -80,7 +81,7 @@
 
 #if (defined (__linux) || defined (linux)) && !defined (__ARDUINO_X86__)
     #include <RF24/RF24_config.h>
-	
+
 //ATXMega
 #elif defined(XMEGA)
 	#include "../../rf24lib/rf24lib/RF24_config.h"
@@ -91,15 +92,15 @@
   #if !defined (ARDUINO_ARCH_AVR)
     #ifndef sprintf_P
       #define sprintf_P sprintf
-    #endif    
+    #endif
   #endif
-  
+
     #if defined (SERIAL_DEBUG_MINIMAL)
       #define IF_SERIAL_DEBUG_MINIMAL(x) ({x;})
     #else
       #define IF_SERIAL_DEBUG_MINIMAL(x)
     #endif
-  
+
     #if defined (SERIAL_DEBUG_FRAGMENTATION)
       #define IF_SERIAL_DEBUG_FRAGMENTATION(x) ({x;})
     #else
@@ -111,13 +112,13 @@
     #else
       #define IF_SERIAL_DEBUG_FRAGMENTATION_L2(x)
     #endif
-  
+
     #if defined (SERIAL_DEBUG_ROUTING)
       #define IF_SERIAL_DEBUG_ROUTING(x) ({x;})
     #else
       #define IF_SERIAL_DEBUG_ROUTING(x)
     #endif
-    
+
 
 #endif //RF24_CONFIG_H
 

--- a/doxygen-custom.css
+++ b/doxygen-custom.css
@@ -1,0 +1,815 @@
+/* The standard CSS for doxygen */
+
+body, table, div, p, dl {
+    font-family: Lucida Grande, Verdana, Geneva, Arial, sans-serif;
+    font-size: 12px;
+}
+
+/* @group Heading Levels */
+
+h1 {
+    font-size: 150%;
+}
+
+.title {
+    font-size: 150%;
+    font-weight: bold;
+    margin: 10px 2px;
+}
+
+h2 {
+    font-size: 120%;
+}
+
+h3 {
+    font-size: 100%;
+}
+
+dt {
+    font-weight: bold;
+}
+
+div.multicol {
+    -moz-column-gap: 1em;
+    -webkit-column-gap: 1em;
+    -moz-column-count: 3;
+    -webkit-column-count: 3;
+}
+
+p.startli, p.startdd, p.starttd {
+    margin-top: 2px;
+}
+
+p.endli {
+    margin-bottom: 0px;
+}
+
+p.enddd {
+    margin-bottom: 4px;
+}
+
+p.endtd {
+    margin-bottom: 2px;
+}
+
+/* @end */
+
+caption {
+    font-weight: bold;
+}
+
+span.legend {
+    font-size: 70%;
+    text-align: center;
+}
+
+h3.version {
+    font-size: 90%;
+    text-align: center;
+}
+
+div.qindex, div.navtab {
+    background-color: #EBEFF6;
+    border: 1px solid #A3B4D7;
+    text-align: center;
+    margin: 2px;
+    padding: 2px;
+}
+
+div.qindex, div.navpath {
+    width: 100%;
+    line-height: 110%;
+}
+
+div.navtab {
+    margin-right: 15px;
+}
+
+/* @group Link Styling */
+
+a {
+    color: #3D578C;
+    font-weight: normal;
+    text-decoration: none;
+}
+
+.contents a:visited {
+    color: #4665A2;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+a.qindex {
+    font-weight: bold;
+}
+
+a.qindexHL {
+    font-weight: bold;
+    background-color: #9CAFD4;
+    color: #ffffff;
+    border: 1px double #869DCA;
+}
+
+.contents a.qindexHL:visited {
+    color: #ffffff;
+}
+
+a.el {
+    font-weight: bold;
+}
+
+a.elRef {
+}
+
+a.code {
+    color: #4665A2;
+}
+
+a.codeRef {
+    color: #4665A2;
+}
+
+/* @end */
+
+dl.el {
+    margin-left: -1cm;
+}
+
+.fragment {
+    font-family: monospace, fixed;
+    font-size: 105%;
+}
+
+pre.fragment {
+    border: 1px solid #C4CFE5;
+    background-color: #FBFCFD;
+    padding: 4px 6px;
+    margin: 4px 8px 4px 2px;
+    overflow: auto;
+    word-wrap: break-word;
+    font-size: 9pt;
+    line-height: 125%;
+}
+
+div.ah {
+    background-color: black;
+    font-weight: bold;
+    color: #ffffff;
+    margin-bottom: 3px;
+    margin-top: 3px;
+    padding: 0.2em;
+    border: solid thin #333;
+    border-radius: 0.5em;
+    -webkit-border-radius: .5em;
+    -moz-border-radius: .5em;
+    box-shadow: 2px 2px 3px #999;
+    -webkit-box-shadow: 2px 2px 3px #999;
+    -moz-box-shadow: rgba(0, 0, 0, 0.15) 2px 2px 2px;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#eee), to(#000), color-stop(0.3, #444));
+    background-image: -moz-linear-gradient(center top, #eee 0%, #444 40%, #000);
+}
+
+div.groupHeader {
+    margin-left: 16px;
+    margin-top: 12px;
+    font-weight: bold;
+}
+
+div.groupText {
+    margin-left: 16px;
+    font-style: italic;
+}
+
+body {
+    background: white;
+    color: black;
+    margin: 0;
+}
+
+div.contents {
+    margin-top: 10px;
+    margin-left: 10px;
+    margin-right: 5px;
+}
+
+td.indexkey {
+    background-color: #EBEFF6;
+    font-weight: bold;
+    border: 1px solid #C4CFE5;
+    margin: 2px 0px 2px 0;
+    padding: 2px 10px;
+}
+
+td.indexvalue {
+    background-color: #EBEFF6;
+    border: 1px solid #C4CFE5;
+    padding: 2px 10px;
+    margin: 2px 0px;
+}
+
+tr.memlist {
+    background-color: #EEF1F7;
+}
+
+p.formulaDsp {
+    text-align: center;
+}
+
+img.formulaDsp {
+
+}
+
+img.formulaInl {
+    vertical-align: middle;
+}
+
+div.center {
+    text-align: center;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    padding: 0px;
+}
+
+div.center img {
+    border: 0px;
+}
+
+address.footer {
+    text-align: right;
+    padding-right: 12px;
+}
+
+img.footer {
+    border: 0px;
+    vertical-align: middle;
+}
+
+/* @group Code Colorization */
+
+span.keyword {
+    color: #008000
+}
+
+span.keywordtype {
+    color: #604020
+}
+
+span.keywordflow {
+    color: #e08000
+}
+
+span.comment {
+    color: #800000
+}
+
+span.preprocessor {
+    color: #806020
+}
+
+span.stringliteral {
+    color: #002080
+}
+
+span.charliteral {
+    color: #008080
+}
+
+span.vhdldigit {
+    color: #ff00ff
+}
+
+span.vhdlchar {
+    color: #000000
+}
+
+span.vhdlkeyword {
+    color: #700070
+}
+
+span.vhdllogic {
+    color: #ff0000
+}
+
+/* @end */
+
+/*
+.search {
+	color: #003399;
+	font-weight: bold;
+}
+
+form.search {
+	margin-bottom: 0px;
+	margin-top: 0px;
+}
+
+input.search {
+	font-size: 75%;
+	color: #000080;
+	font-weight: normal;
+	background-color: #e8eef2;
+}
+*/
+
+td.tiny {
+    font-size: 75%;
+}
+
+.dirtab {
+    padding: 4px;
+    border-collapse: collapse;
+    border: 1px solid #A3B4D7;
+}
+
+th.dirtab {
+    background: #EBEFF6;
+    font-weight: bold;
+}
+
+hr {
+    height: 0px;
+    border: none;
+    border-top: 1px solid #4A6AAA;
+}
+
+hr.footer {
+    height: 1px;
+}
+
+/* @group Member Descriptions */
+
+table.memberdecls {
+    border-spacing: 0px;
+    padding: 0px;
+}
+
+.mdescLeft, .mdescRight,
+.memItemLeft, .memItemRight,
+.memTemplItemLeft, .memTemplItemRight, .memTemplParams {
+    background-color: #F9FAFC;
+    border: none;
+    margin: 4px;
+    padding: 1px 0 0 8px;
+}
+
+.mdescLeft, .mdescRight {
+    padding: 0px 8px 4px 8px;
+    color: #555;
+}
+
+.memItemLeft, .memItemRight, .memTemplParams {
+    border-top: 1px solid #C4CFE5;
+}
+
+.memItemLeft, .memTemplItemLeft {
+    white-space: nowrap;
+}
+
+.memItemRight {
+    width: 100%;
+}
+
+.memTemplParams {
+    color: #4665A2;
+    white-space: nowrap;
+}
+
+/* @end */
+
+/* @group Member Details */
+
+/* Styles for detailed member documentation */
+
+.memtemplate {
+    font-size: 80%;
+    color: #4665A2;
+    font-weight: normal;
+    margin-left: 9px;
+}
+
+.memnav {
+    background-color: #EBEFF6;
+    border: 1px solid #A3B4D7;
+    text-align: center;
+    margin: 2px;
+    margin-right: 15px;
+    padding: 2px;
+}
+
+.mempage {
+    width: 100%;
+}
+
+.memitem {
+    padding: 0;
+    margin-bottom: 10px;
+    margin-right: 5px;
+}
+
+.memname {
+    white-space: nowrap;
+    font-weight: bold;
+    margin-left: 6px;
+}
+
+.memproto {
+    border-top: 1px solid #A8B8D9;
+    border-left: 1px solid #A8B8D9;
+    border-right: 1px solid #A8B8D9;
+    padding: 6px 0px 6px 0px;
+    color: #253555;
+    font-weight: bold;
+    text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
+    /* opera specific markup */
+    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    border-top-right-radius: 8px;
+    border-top-left-radius: 8px;
+    /* firefox specific markup */
+    -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
+    -moz-border-radius-topright: 8px;
+    -moz-border-radius-topleft: 8px;
+    /* webkit specific markup */
+    -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    -webkit-border-top-right-radius: 8px;
+    -webkit-border-top-left-radius: 8px;
+    background-image: url('nav_f.png');
+    background-repeat: repeat-x;
+    background-color: #E2E8F2;
+
+}
+
+.memdoc {
+    border-bottom: 1px solid #A8B8D9;
+    border-left: 1px solid #A8B8D9;
+    border-right: 1px solid #A8B8D9;
+    padding: 2px 5px;
+    background-color: #FBFCFD;
+    border-top-width: 0;
+    /* opera specific markup */
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    /* firefox specific markup */
+    -moz-border-radius-bottomleft: 8px;
+    -moz-border-radius-bottomright: 8px;
+    -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
+    background-image: -moz-linear-gradient(center top, #FFFFFF 0%, #FFFFFF 60%, #F7F8FB 95%, #EEF1F7);
+    /* webkit specific markup */
+    -webkit-border-bottom-left-radius: 8px;
+    -webkit-border-bottom-right-radius: 8px;
+    -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    background-image: -webkit-gradient(linear, center top, center bottom, from(#FFFFFF), color-stop(0.6, #FFFFFF), color-stop(0.60, #FFFFFF), color-stop(0.95, #F7F8FB), to(#EEF1F7));
+}
+
+.paramkey {
+    text-align: right;
+}
+
+.paramtype {
+    white-space: nowrap;
+}
+
+.paramname {
+    color: #602020;
+    white-space: nowrap;
+}
+
+.paramname em {
+    font-style: normal;
+}
+
+.params, .retval, .exception, .tparams {
+    border-spacing: 6px 2px;
+}
+
+.params .paramname, .retval .paramname {
+    font-weight: bold;
+    vertical-align: top;
+}
+
+.params .paramtype {
+    font-style: italic;
+    vertical-align: top;
+}
+
+.params .paramdir {
+    font-family: "courier new", courier, monospace;
+    vertical-align: top;
+}
+
+
+/* @end */
+
+/* @group Directory (tree) */
+
+/* for the tree view */
+
+.ftvtree {
+    font-family: sans-serif;
+    margin: 0px;
+}
+
+/* these are for tree view when used as main index */
+
+.directory {
+    font-size: 9pt;
+    font-weight: bold;
+    margin: 5px;
+}
+
+.directory h3 {
+    margin: 0px;
+    margin-top: 1em;
+    font-size: 11pt;
+}
+
+/*
+The following two styles can be used to replace the root node title
+with an image of your choice.  Simply uncomment the next two styles,
+specify the name of your image and be sure to set 'height' to the
+proper pixel height of your image.
+*/
+
+/*
+.directory h3.swap {
+	height: 61px;
+	background-repeat: no-repeat;
+	background-image: url("yourimage.gif");
+}
+.directory h3.swap span {
+	display: none;
+}
+*/
+
+.directory > h3 {
+    margin-top: 0;
+}
+
+.directory p {
+    margin: 0px;
+    white-space: nowrap;
+}
+
+.directory div {
+    display: none;
+    margin: 0px;
+}
+
+.directory img {
+    vertical-align: -30%;
+}
+
+/* these are for tree view when not used as main index */
+
+.directory-alt {
+    font-size: 100%;
+    font-weight: bold;
+}
+
+.directory-alt h3 {
+    margin: 0px;
+    margin-top: 1em;
+    font-size: 11pt;
+}
+
+.directory-alt > h3 {
+    margin-top: 0;
+}
+
+.directory-alt p {
+    margin: 0px;
+    white-space: nowrap;
+}
+
+.directory-alt div {
+    display: none;
+    margin: 0px;
+}
+
+.directory-alt img {
+    vertical-align: -30%;
+}
+
+/* @end */
+
+div.dynheader {
+    margin-top: 8px;
+}
+
+address {
+    font-style: normal;
+    color: #2A3D61;
+}
+
+table.doxtable {
+    border-collapse: collapse;
+}
+
+table.doxtable td, table.doxtable th {
+    border: 1px solid #2D4068;
+    padding: 3px 7px 2px;
+}
+
+table.doxtable th {
+    background-color: #374F7F;
+    color: #FFFFFF;
+    font-size: 110%;
+    padding-bottom: 4px;
+    padding-top: 5px;
+    text-align: left;
+}
+
+.tabsearch {
+    top: 0px;
+    left: 10px;
+    height: 36px;
+    background-image: url('tab_b.png');
+    z-index: 101;
+    overflow: hidden;
+    font-size: 13px;
+}
+
+.navpath ul {
+    font-size: 11px;
+    background-image: url('tab_b.png');
+    background-repeat: repeat-x;
+    height: 30px;
+    line-height: 30px;
+    color: #8AA0CC;
+    border: solid 1px #C2CDE4;
+    overflow: hidden;
+    margin: 0px;
+    padding: 0px;
+}
+
+.navpath li {
+    list-style-type: none;
+    float: left;
+    padding-left: 10px;
+    padding-right: 15px;
+    background-image: url('bc_s.png');
+    background-repeat: no-repeat;
+    background-position: right;
+    color: #364D7C;
+}
+
+.navpath li.navelem a {
+    height: 32px;
+    display: block;
+    text-decoration: none;
+    outline: none;
+}
+
+.navpath li.navelem a:hover {
+    color: #6884BD;
+}
+
+.navpath li.footer {
+    list-style-type: none;
+    float: right;
+    padding-left: 10px;
+    padding-right: 15px;
+    background-image: none;
+    background-repeat: no-repeat;
+    background-position: right;
+    color: #364D7C;
+    font-size: 8pt;
+}
+
+
+div.summary {
+    float: right;
+    font-size: 8pt;
+    padding-right: 5px;
+    width: 50%;
+    text-align: right;
+}
+
+div.summary a {
+    white-space: nowrap;
+}
+
+div.ingroups {
+    font-size: 8pt;
+    padding-left: 5px;
+    width: 50%;
+    text-align: left;
+}
+
+div.ingroups a {
+    white-space: nowrap;
+}
+
+div.header {
+    background-image: url('nav_h.png');
+    background-repeat: repeat-x;
+    background-color: #F9FAFC;
+    margin: 0px;
+    border-bottom: 1px solid #C4CFE5;
+}
+
+div.headertitle {
+    padding: 5px 5px 5px 10px;
+}
+
+dl {
+    padding: 0 0 0 10px;
+}
+
+dl.note, dl.warning, dl.attention, dl.pre, dl.post, dl.invariant, dl.deprecated, dl.todo, dl.test, dl.bug {
+    border-left: 4px solid;
+    padding: 0 0 0 6px;
+}
+
+dl.note {
+    border-color: #D0C000;
+}
+
+dl.warning, dl.attention {
+    border-color: #FF0000;
+}
+
+dl.pre, dl.post, dl.invariant {
+    border-color: #00D000;
+}
+
+dl.deprecated {
+    border-color: #505050;
+}
+
+dl.todo {
+    border-color: #00C0E0;
+}
+
+dl.test {
+    border-color: #3030E0;
+}
+
+dl.bug {
+    border-color: #C08050;
+}
+
+#projectlogo {
+    text-align: center;
+    vertical-align: bottom;
+    border-collapse: separate;
+}
+
+#projectlogo img {
+    border: 0px none;
+}
+
+#projectname {
+    font: 300% Tahoma, Arial, sans-serif;
+    margin: 0px;
+    padding: 2px 0px;
+}
+
+#projectbrief {
+    font: 120% Tahoma, Arial, sans-serif;
+    margin: 0px;
+    padding: 0px;
+}
+
+#projectnumber {
+    font: 50% Tahoma, Arial, sans-serif;
+    margin: 0px;
+    padding: 0px;
+}
+
+#titlearea {
+    padding: 0px;
+    margin: 0px;
+    width: 100%;
+    border-bottom: 1px solid #5373B4;
+}
+
+.image {
+    text-align: left;
+}
+
+.dotgraph {
+    text-align: center;
+}
+
+.mscgraph {
+    text-align: center;
+}
+
+.caption {
+    font-weight: bold;
+}
+td.fielddoc
+th.markdownTableHeadLeft,
+th.markdownTableHeadRight,
+th.markdownTableHeadCenter,
+th.markdownTableHeadNone {
+    background-image: none;
+    border-radius: unset;
+}
+
+td.fielddoc tr:last-child {
+    border-bottom: 1px solid #2D4068;
+}

--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=TMRh20,Avamander
 sentence=OSI Layer 3 Networking for nrf24L01(+) devices.
 paragraph=Provides a simple and seamless network layer for sensor/IoT networks, including routing, addressing and fragmentation/reassembly.
 category=Communication
-url=https://tmrh20.github.io/RF24Network/
+url=https://nRF24.github.io/RF24Network/
 architectures=*
 depends=RF24


### PR DESCRIPTION
Introduces a new workflow that:
- only runs on master branch
- only deploys docs on release "publish" or "edit" events
- fetches latest version tag from this repo's releases and uses it to update the Doxyfile's "PROJECT_NUMBER" tag. This tag change is not committed to the Doxyfile, rather it is only used during the workflow.

Additionally, I've
- made fixes for all "addressable" doxygen warnings (`Makefile` is parsed like a C source file because there is no extension -- its a doxygen problem)
    - This includes removing deprecated tags from the Doxyfile (they were using default or invalid options anyway). I didn't use `doxygen -u` for backward compatibility reasons.
- formatted and updated the doxygen-custom.css file
- renamed all links to docs from tmrh20.github.io/\<repo name> to nRF24.github.io/\<repo name> except for:
    - the links to the automatic install/update script at [tmrh20's RF24Installer for RPi](https://github.com/TMRh20/tmrh20.github.io/tree/master/RF24Installer/RPi)
    - any links that lead to tmrh20.github.io main page listing all RF24 repos (links for this page have to be changed separately in the [tmrh20.github.io repo's index.html file](https://github.com/TMRh20/tmrh20.github.io/blob/587d08b7b1cc9185fb6bb1185fbf3f42e1546acd/index.html#L33)
- deactivated any LATEX or XML output from doxygen since they're not actually being used (and the LATEX output seems to require 3rd party software to generate properly). 