### PR TITLE
Extra Pipes

### DIFF
--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -1181,7 +1181,14 @@ template<class radio_t>
 uint64_t ESBNetwork<radio_t>::pipe_address(uint16_t node, uint8_t pipe)
 {
 
-    static uint8_t address_translation[] = {0xc3, 0x3c, 0x33, 0xce, 0x3e, 0xe3, 0xec, 0xee, 0xed};
+    static uint8_t address_translation[] = {0xc3, 0x3c, 0x33, 0xce, 0x3e, 0xe3, 0xec
+#if NUM_PIPES > 6
+, 0xee
+    #if NUM_PIPES > 7
+, 0xed
+    #endif
+#endif
+};
     uint64_t result = 0xCCCCCCCCCCLL;
     uint8_t* out = reinterpret_cast<uint8_t*>(&result);
 

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -103,7 +103,7 @@ void ESBNetwork<radio_t>::begin(uint8_t _channel, uint16_t _node_address)
     setup_address();
 
     // Open up all listening pipes
-    uint8_t i = 6;
+    uint8_t i = NUM_PIPES;
     while (i--)
         radio.openReadingPipe(i, pipe_address(_node_address, i));
 
@@ -956,7 +956,7 @@ void ESBNetwork<radio_t>::logicalToPhysicalAddress(logicalToPhysicalStruct* conv
         //}
     }
     else if (is_descendant(*to_node)) {
-        pre_conversion_send_pipe = 5; // Send to its listening pipe
+        pre_conversion_send_pipe = NUM_PIPES - 1; // Send to its listening pipe
         // If the node is a direct child,
         if (is_direct_child(*to_node)) {
             // Send directly
@@ -1131,7 +1131,7 @@ bool ESBNetwork<radio_t>::is_valid_address(uint16_t node)
 #endif
     while (node) {
         uint8_t digit = node & 0x07;
-        if (digit < 1 || digit > 5) {
+        if (digit < 1 || digit > (NUM_PIPES - 1)) {
             result = false;
             IF_SERIAL_DEBUG_MINIMAL(printf_P(PSTR("*** WARNING *** Invalid address 0%o\n\r"), origNode););
             break;
@@ -1181,7 +1181,7 @@ template<class radio_t>
 uint64_t ESBNetwork<radio_t>::pipe_address(uint16_t node, uint8_t pipe)
 {
 
-    static uint8_t address_translation[] = {0xc3, 0x3c, 0x33, 0xce, 0x3e, 0xe3, 0xec};
+    static uint8_t address_translation[] = {0xc3, 0x3c, 0x33, 0xce, 0x3e, 0xe3, 0xec, 0xee, 0xed};
     uint64_t result = 0xCCCCCCCCCCLL;
     uint8_t* out = reinterpret_cast<uint8_t*>(&result);
 

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -81,6 +81,11 @@
         /** Enable dynamic payloads - If using different types of nRF24L01 modules, some may be incompatible when using this feature **/
         #define ENABLE_DYNAMIC_PAYLOADS
     #endif // DISABLE_DYNAMIC_PAYLOADS
+    
+    // The number of 'pipes' available for addressing in the current device
+    // Networks with NRF24L01 devices only have 6 pipes
+    // NRF52x networks support up to 8 pipes
+    #define NUM_PIPES 6
 
     /* Debug Options */
     //#define SERIAL_DEBUG

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -82,7 +82,7 @@
         #define ENABLE_DYNAMIC_PAYLOADS
     #endif // DISABLE_DYNAMIC_PAYLOADS
     
-    /* The number of 'pipes' available for addressing in the current device
+    /** The number of 'pipes' available for addressing in the current device
      * Networks with NRF24L01 devices only have 6 pipes
      * NRF52x networks support up to 8 pipes
      */

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -82,9 +82,10 @@
         #define ENABLE_DYNAMIC_PAYLOADS
     #endif // DISABLE_DYNAMIC_PAYLOADS
     
-    // The number of 'pipes' available for addressing in the current device
-    // Networks with NRF24L01 devices only have 6 pipes
-    // NRF52x networks support up to 8 pipes
+    /* The number of 'pipes' available for addressing in the current device
+     * Networks with NRF24L01 devices only have 6 pipes
+     * NRF52x networks support up to 8 pipes
+     */
     #define NUM_PIPES 6
 
     /* Debug Options */


### PR DESCRIPTION
Finally found some time to play around with this and it was pretty easy to implement. Just a few questions now like whether to try and support mixed networks (I don't really like that idea) but it seems to work fine.

- Add support for any number of 'pipes' that are available for addressing. 
- Allows wider range of addressing on NRF52x devices

Instructions:
- Edit RF24Network_config.h and set NUM_PIPES to 8
- Edit RF24Mesh_config.h and set MESH_MAX_CHILDREN to 6
- Recompile and upload...

#201