### PR TITLE
Modifications for 64-bit OS

### DIFF
--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -1181,14 +1181,22 @@ template<class radio_t>
 uint64_t ESBNetwork<radio_t>::pipe_address(uint16_t node, uint8_t pipe)
 {
 
-    static uint8_t address_translation[] = {0xc3, 0x3c, 0x33, 0xce, 0x3e, 0xe3, 0xec
+    static uint8_t address_translation[] = { 0xc3,
+                                             0x3c,
+                                             0x33,
+                                             0xce,
+                                             0x3e,
+                                             0xe3,
+                                             0xec
 #if NUM_PIPES > 6
-, 0xee
+                                             ,
+                                             0xee
     #if NUM_PIPES > 7
-, 0xed
+                                             ,
+                                             0xed
     #endif
 #endif
-};
+    };
     uint64_t result = 0xCCCCCCCCCCLL;
     uint8_t* out = reinterpret_cast<uint8_t*>(&result);
 

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -81,7 +81,7 @@
         /** Enable dynamic payloads - If using different types of nRF24L01 modules, some may be incompatible when using this feature **/
         #define ENABLE_DYNAMIC_PAYLOADS
     #endif // DISABLE_DYNAMIC_PAYLOADS
-    
+
     /** The number of 'pipes' available for addressing in the current device
      * Networks with NRF24L01 devices only have 6 pipes
      * NRF52x networks support up to 8 pipes

--- a/examples_RPi/helloworld_rx.cpp
+++ b/examples_RPi/helloworld_rx.cpp
@@ -45,7 +45,6 @@ int main(int argc, char** argv)
     delay(5);
     radio.setChannel(90);
     network.begin(/*node address*/ this_node);
-    radio.setPALevel(RF24_PA_HIGH,0);
     radio.printDetails();
 
     while (1) {

--- a/examples_RPi/helloworld_rx.cpp
+++ b/examples_RPi/helloworld_rx.cpp
@@ -29,8 +29,8 @@ const uint16_t other_node = 01;
 
 struct payload_t
 { // Structure of our payload
-    unsigned long ms;
-    unsigned long counter;
+    uint32_t ms;
+    uint32_t counter;
 };
 
 int main(int argc, char** argv)

--- a/examples_RPi/helloworld_rx.cpp
+++ b/examples_RPi/helloworld_rx.cpp
@@ -45,6 +45,7 @@ int main(int argc, char** argv)
     delay(5);
     radio.setChannel(90);
     network.begin(/*node address*/ this_node);
+    radio.setPALevel(RF24_PA_HIGH,0);
     radio.printDetails();
 
     while (1) {
@@ -56,7 +57,7 @@ int main(int argc, char** argv)
             payload_t payload;
             network.read(header, &payload, sizeof(payload));
 
-            printf("Received payload: counter=%lu, origin timestamp=%lu\n", payload.counter, payload.ms);
+            printf("Received payload: counter=%u, origin timestamp=%u\n", payload.counter, payload.ms);
         }
         //sleep(2);
         delay(2000);

--- a/examples_RPi/helloworld_tx.cpp
+++ b/examples_RPi/helloworld_tx.cpp
@@ -32,13 +32,13 @@ const uint16_t other_node = 00;
 // How often (in milliseconds) to send a message to the `other_node`
 const unsigned long interval = 2000;
 
-unsigned long last_sent;    // When did we last send?
-unsigned long packets_sent; // How many have we sent already
+uint32_t last_sent;    // When did we last send?
+uint32_t packets_sent; // How many have we sent already
 
 struct payload_t
 { // Structure of our payload
-    unsigned long ms;
-    unsigned long counter;
+    uint32_t ms;
+    uint32_t counter;
 };
 
 int main(int argc, char** argv)
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
     while (1) {
 
         network.update();
-        unsigned long now = millis(); // If it's time to send a message, send it!
+        uint32_t now = millis(); // If it's time to send a message, send it!
         if (now - last_sent >= interval) {
             last_sent = now;
 

--- a/examples_RPi/rx-test.cpp
+++ b/examples_RPi/rx-test.cpp
@@ -27,17 +27,17 @@ const uint16_t other_node = 01;
 
 struct payload_power_t
 { // Structure of our payload
-    unsigned long nodeId;
+    uint32_t nodeId;
     float power;
     float current;
 };
 
 struct payload_weather_t
 {
-    unsigned long nodeId;
+    uint32_t nodeId;
     float temperature;
     float humidity;
-    unsigned long lux;
+    uint32_t lux;
 };
 
 int main(int argc, char** argv)


### PR DESCRIPTION
All I did was change unsigned long to uint32_t in examples, and now the formatting check is failing lol. I'm thinking we should use the version of clang-format that ships with RPi, which is currently 14.0.6 on my RPi5.

In any case, I'm not sure whether to make the same changes in the regular Arduino and Pico examples, because I don't think there are any 64-bit Arduinos yet.
We might want to change it for continuity, so they all read the same, but that would be the only reason I think.