### PR TITLE
Fix: Need NUM_PIPES defined for all devices

### DIFF
--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -34,6 +34,12 @@
     #define SLOW_ADDR_POLL_RESPONSE 10
 #endif // defined DOXYGEN_FORCED
 
+/** The number of 'pipes' available for addressing in the current device
+ * Networks with NRF24L01 devices only have 6 pipes
+ * NRF52x networks support up to 8 pipes
+ */
+#define NUM_PIPES 6
+
 #if !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny84__)
 
     /********** USER CONFIG - non ATTiny **************/
@@ -81,12 +87,6 @@
         /** Enable dynamic payloads - If using different types of nRF24L01 modules, some may be incompatible when using this feature **/
         #define ENABLE_DYNAMIC_PAYLOADS
     #endif // DISABLE_DYNAMIC_PAYLOADS
-
-    /** The number of 'pipes' available for addressing in the current device
-     * Networks with NRF24L01 devices only have 6 pipes
-     * NRF52x networks support up to 8 pipes
-     */
-    #define NUM_PIPES 6
 
     /* Debug Options */
     //#define RF24NETWORK_DEBUG


### PR DESCRIPTION
Tried to compile for ATTiny and it failed because NUM_PIPES was not defined for ATTiny.