### PR TITLE
Fix for large payloads with NRF52

### DIFF
--- a/.github/workflows/build_nrf_to_nrf.yml
+++ b/.github/workflows/build_nrf_to_nrf.yml
@@ -1,0 +1,25 @@
+name: nRF52840 build
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    uses: nRF24/.github/.github/workflows/build_platformio.yaml@main
+    with:
+      example-path: ${{ matrix.example }}
+      board-id: ${{ matrix.board }}
+      lib-deps: -l https://github.com/TMRh20/nrf_to_nrf.git
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - "examples/nrf_to_nrf/helloworld_rx/helloworld_rx.ino"
+          - "examples/nrf_to_nrf/helloworld_tx/helloworld_tx.ino"
+          - "examples/nrf_to_nrf/helloworld_rxEncryption/helloworld_rxEncryption.ino"
+          - "examples/nrf_to_nrf/helloworld_txEncryption/helloworld_txEncryption.ino"
+        board:
+          - "adafruit_feather_nrf52840"

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -704,7 +704,7 @@ bool ESBNetwork<radio_t>::beginWrite(radioTag<RF24>, RF24NetworkHeader& header, 
 }
 
 /******************************************************************/
-#if defined (NRF52_RADIO_LIBRARY)
+#if defined(NRF52_RADIO_LIBRARY)
 template<class radio_t>
 bool ESBNetwork<radio_t>::beginWrite(radioTag<nrf_to_nrf>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
 {

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -722,7 +722,7 @@ bool ESBNetwork<radio_t>::main_write(RF24NetworkHeader& header, const void* mess
 
 #if defined(DISABLE_FRAGMENTATION)
 
-    frame_size = rf24_min(len + sizeof(RF24NetworkHeader), max_frame_payload_size + sizeof(RF24NetworkHeader);
+    frame_size = rf24_min(len + sizeof(RF24NetworkHeader), max_frame_payload_size + sizeof(RF24NetworkHeader));
     return _write(header, message, rf24_min(len, max_frame_payload_size), writeDirect);
 
 #else // !defined(DISABLE_FRAGMENTATION)

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -725,7 +725,7 @@ bool ESBNetwork<radio_t>::write(RF24NetworkHeader& header, const void* message, 
 
 #if defined(DISABLE_FRAGMENTATION)
 
-    frame_size = rf24_min(len + sizeof(RF24NetworkHeader), max_frame_size;
+    frame_size = rf24_min(len + sizeof(RF24NetworkHeader), max_frame_size);
     return _write(header, message, rf24_min(len, max_frame_payload_size), writeDirect);
 
 #else // !defined(DISABLE_FRAGMENTATION)

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -691,13 +691,13 @@ bool ESBNetwork<radio_t>::multicast(RF24NetworkHeader& header, const void* messa
 template<class radio_t>
 bool ESBNetwork<radio_t>::write(RF24NetworkHeader& header, const void* message, uint16_t len)
 {
-    return beginWrite(radioTag<radio_t> {}, header, message, len, NETWORK_AUTO_ROUTING);
+    return beginWrite(header, message, len, NETWORK_AUTO_ROUTING);
 }
 
 /******************************************************************/
 
-template<class radio_t>
-bool ESBNetwork<radio_t>::beginWrite(radioTag<RF24>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
+template<>
+bool ESBNetwork<RF24>::beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
 {
     max_frame_size = MAX_FRAME_SIZE;
     return write(header, message, len, writeDirect);
@@ -705,8 +705,8 @@ bool ESBNetwork<radio_t>::beginWrite(radioTag<RF24>, RF24NetworkHeader& header, 
 
 /******************************************************************/
 #if defined(NRF52_RADIO_LIBRARY)
-template<class radio_t>
-bool ESBNetwork<radio_t>::beginWrite(radioTag<nrf_to_nrf>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
+template<>
+bool ESBNetwork<nrf_to_nrf>::beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
 {
     max_frame_size = (uint8_t)NRF_RADIO->PCNF1;
     if (radio.enableEncryption == true) {

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -704,7 +704,7 @@ bool ESBNetwork<radio_t>::beginWrite(radioTag<RF24>, RF24NetworkHeader& header, 
 }
 
 /******************************************************************/
-
+#if defined (NRF52_RADIO_LIBRARY)
 template<class radio_t>
 bool ESBNetwork<radio_t>::beginWrite(radioTag<nrf_to_nrf>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
 {
@@ -714,7 +714,7 @@ bool ESBNetwork<radio_t>::beginWrite(radioTag<nrf_to_nrf>, RF24NetworkHeader& he
     }
     return write(header, message, len, writeDirect);
 }
-
+#endif
 /******************************************************************/
 
 template<class radio_t>

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -706,7 +706,7 @@ bool ESBNetwork<radio_t>::write(RF24NetworkHeader& header, const void* message, 
       max_frame_size -= CCM_IV_SIZE + CCM_COUNTER_SIZE + CCM_MIC_SIZE;
     }*/
 #else
-    max_frame_size = MAX_FRAME_BUFFER_SIZE;
+    max_frame_size = MAX_FRAME_SIZE;
 #endif
     max_frame_payload_size = max_frame_size - sizeof(RF24NetworkHeader);
 

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -699,7 +699,7 @@ bool ESBNetwork<radio_t>::write(RF24NetworkHeader& header, const void* message, 
 template<>
 bool ESBNetwork<RF24>::write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
 {
-    max_frame_size = MAX_FRAME_SIZE;
+    max_frame_payload_size = MAX_FRAME_SIZE - sizeof(RF24NetworkHeader);
     return main_write(header, message, len, writeDirect);
 }
 
@@ -708,9 +708,9 @@ bool ESBNetwork<RF24>::write(RF24NetworkHeader& header, const void* message, uin
 template<>
 bool ESBNetwork<nrf_to_nrf>::write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
 {
-    max_frame_size = (uint8_t)NRF_RADIO->PCNF1;
+    max_frame_payload_size = (uint8_t)NRF_RADIO->PCNF1 - sizeof(RF24NetworkHeader);
     if (radio.enableEncryption == true) {
-        max_frame_size -= CCM_IV_SIZE + CCM_COUNTER_SIZE + CCM_MIC_SIZE;
+        max_frame_payload_size -= CCM_IV_SIZE + CCM_COUNTER_SIZE + CCM_MIC_SIZE;
     }
     return main_write(header, message, len, writeDirect);
 }
@@ -720,11 +720,10 @@ bool ESBNetwork<nrf_to_nrf>::write(RF24NetworkHeader& header, const void* messag
 template<class radio_t>
 bool ESBNetwork<radio_t>::main_write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
 {
-    max_frame_payload_size = max_frame_size - sizeof(RF24NetworkHeader);
 
 #if defined(DISABLE_FRAGMENTATION)
 
-    frame_size = rf24_min(len + sizeof(RF24NetworkHeader), max_frame_size);
+    frame_size = rf24_min(len + sizeof(RF24NetworkHeader), max_frame_payload_size + sizeof(RF24NetworkHeader);
     return _write(header, message, rf24_min(len, max_frame_payload_size), writeDirect);
 
 #else // !defined(DISABLE_FRAGMENTATION)

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -699,8 +699,27 @@ bool ESBNetwork<radio_t>::write(RF24NetworkHeader& header, const void* message, 
 template<>
 bool ESBNetwork<RF24>::write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
 {
-
     max_frame_size = MAX_FRAME_SIZE;
+    return main_write(header, message, len, writeDirect);
+}
+
+/******************************************************************/
+#if defined NRF52_RADIO_LIBRARY
+template<>
+bool ESBNetwork<nrf_to_nrf>::write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
+{
+    max_frame_size = (uint8_t)NRF_RADIO->PCNF1;
+    if (radio.enableEncryption == true) {
+        max_frame_size -= CCM_IV_SIZE + CCM_COUNTER_SIZE + CCM_MIC_SIZE;
+    }
+    return main_write(header, message, len, writeDirect);
+}
+#endif
+/******************************************************************/
+
+template<class radio_t>
+bool ESBNetwork<radio_t>::main_write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
+{
     max_frame_payload_size = max_frame_size - sizeof(RF24NetworkHeader);
 
 #if defined(DISABLE_FRAGMENTATION)
@@ -801,117 +820,6 @@ bool ESBNetwork<RF24>::write(RF24NetworkHeader& header, const void* message, uin
 #endif //Fragmentation enabled
 }
 
-/******************************************************************/
-
-#if defined NRF52_RADIO_LIBRARY
-template<>
-bool ESBNetwork<nrf_to_nrf>::write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
-{
-
-    max_frame_size = (uint8_t)NRF_RADIO->PCNF1;
-    if (radio.enableEncryption == true) {
-        max_frame_size -= CCM_IV_SIZE + CCM_COUNTER_SIZE + CCM_MIC_SIZE;
-    }
-    max_frame_payload_size = max_frame_size - sizeof(RF24NetworkHeader);
-
-    #if defined(DISABLE_FRAGMENTATION)
-
-    frame_size = rf24_min(len + sizeof(RF24NetworkHeader), max_frame_size);
-    return _write(header, message, rf24_min(len, max_frame_payload_size), writeDirect);
-
-    #else // !defined(DISABLE_FRAGMENTATION)
-
-    if (len <= max_frame_payload_size) {
-        //Normal Write (Un-Fragmented)
-        frame_size = len + sizeof(RF24NetworkHeader);
-        return _write(header, message, len, writeDirect);
-    }
-    //Check payload size
-
-    if (len > MAX_PAYLOAD_SIZE) {
-        IF_RF24NETWORK_DEBUG(printf_P(PSTR("NET write message failed. Given 'len' %d is bigger than the MAX Payload size %i\n\r"), len, MAX_PAYLOAD_SIZE););
-        return false;
-    }
-
-    //Divide the message payload into chunks of max_frame_payload_size
-    uint8_t fragment_id = (len % max_frame_payload_size != 0) + ((len) / max_frame_payload_size); //the number of fragments to send = ceil(len/max_frame_payload_size)
-
-    uint8_t msgCount = 0;
-
-    IF_RF24NETWORK_DEBUG_FRAGMENTATION(printf_P(PSTR("FRG Total message fragments %d\n\r"), fragment_id););
-
-    if (header.to_node != NETWORK_MULTICAST_ADDRESS) {
-        networkFlags |= FLAG_FAST_FRAG;
-        radio.stopListening();
-    }
-
-    uint8_t retriesPerFrag = 0;
-    uint8_t type = header.type;
-    bool ok = 0;
-
-    while (fragment_id > 0) {
-
-        //Copy and fill out the header
-        //RF24NetworkHeader fragmentHeader = header;
-        header.reserved = fragment_id;
-
-        if (fragment_id == 1) {
-            header.type = NETWORK_LAST_FRAGMENT; //Set the last fragment flag to indicate the last fragment
-            header.reserved = type;              //The reserved field is used to transmit the header type
-        }
-        else if (msgCount == 0) {
-            header.type = NETWORK_FIRST_FRAGMENT;
-        }
-        else {
-            header.type = NETWORK_MORE_FRAGMENTS; //Set the more fragments flag to indicate a fragmented frame
-        }
-
-        uint16_t offset = msgCount * max_frame_payload_size;
-        uint16_t fragmentLen = rf24_min((uint16_t)(len - offset), max_frame_payload_size);
-
-        //Try to send the payload chunk with the copied header
-        frame_size = sizeof(RF24NetworkHeader) + fragmentLen;
-        ok = _write(header, ((char*)message) + offset, fragmentLen, writeDirect);
-
-        if (!ok) {
-            delay(2);
-            ++retriesPerFrag;
-        }
-        else {
-            retriesPerFrag = 0;
-            fragment_id--;
-            msgCount++;
-        }
-
-        //if(writeDirect != NETWORK_AUTO_ROUTING){ delay(2); } //Delay 2ms between sending multicast payloads
-
-        if (!ok && retriesPerFrag >= 3) {
-            IF_RF24NETWORK_DEBUG_FRAGMENTATION(printf_P(PSTR("FRG TX with fragmentID '%d' failed after %d fragments. Abort.\n\r"), fragment_id, msgCount));
-            break;
-        }
-
-        // Message was successful sent
-        IF_RF24NETWORK_DEBUG_FRAGMENTATION_L2(printf_P(PSTR("FRG message transmission with fragmentID '%d' successful.\n\r"), fragment_id));
-    }
-    header.type = type;
-    if (networkFlags & FLAG_FAST_FRAG) {
-        ok = radio.txStandBy(txTimeout);
-        radio.startListening();
-        radio.setAutoAck(0, 0);
-    }
-    networkFlags &= ~FLAG_FAST_FRAG;
-
-    // Return true if all the chunks where sent successfully
-    IF_RF24NETWORK_DEBUG_FRAGMENTATION(printf_P(PSTR("FRG total message fragments sent %i.\r\n"), msgCount););
-
-    if (!ok || fragment_id > 0) {
-        return false;
-    }
-    return true;
-
-    #endif //Fragmentation enabled
-}
-#endif //NRF52_RADIO_LIBRARY
 /******************************************************************/
 
 template<class radio_t>

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -699,7 +699,6 @@ bool ESBNetwork<radio_t>::write(RF24NetworkHeader& header, const void* message, 
 template<>
 bool ESBNetwork<RF24>::write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
 {
-    max_frame_payload_size = MAX_FRAME_SIZE - sizeof(RF24NetworkHeader);
     return main_write(header, message, len, writeDirect);
 }
 

--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -688,31 +688,23 @@ bool ESBNetwork<radio_t>::multicast(RF24NetworkHeader& header, const void* messa
 
 /******************************************************************/
 
-template<class radio_t>
-bool ESBNetwork<radio_t>::write(RF24NetworkHeader& header, const void* message, uint16_t len)
-{
-    return beginWrite(header, message, len, NETWORK_AUTO_ROUTING);
-}
-
-/******************************************************************/
-
 template<>
-bool ESBNetwork<RF24>::beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
+bool ESBNetwork<RF24>::write(RF24NetworkHeader& header, const void* message, uint16_t len)
 {
     max_frame_size = MAX_FRAME_SIZE;
-    return write(header, message, len, writeDirect);
+    return write(header, message, len, NETWORK_AUTO_ROUTING);
 }
 
 /******************************************************************/
 #if defined(NRF52_RADIO_LIBRARY)
 template<>
-bool ESBNetwork<nrf_to_nrf>::beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect)
+bool ESBNetwork<nrf_to_nrf>::write(RF24NetworkHeader& header, const void* message, uint16_t len)
 {
     max_frame_size = (uint8_t)NRF_RADIO->PCNF1;
     if (radio.enableEncryption == true) {
         max_frame_size -= CCM_IV_SIZE + CCM_COUNTER_SIZE + CCM_MIC_SIZE;
     }
-    return write(header, message, len, writeDirect);
+    return write(header, message, len, NETWORK_AUTO_ROUTING);
 }
 #endif
 /******************************************************************/

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -917,11 +917,11 @@ private:
     {
     };
     bool beginWrite(radioTag<RF24>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
-    
-    #if defined (NRF52_RADIO_LIBRARY)
+
+#if defined(NRF52_RADIO_LIBRARY)
     bool beginWrite(radioTag<nrf_to_nrf>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
-    #endif
-    
+#endif
+
     struct logicalToPhysicalStruct
     {
         /** The immediate destination (1 hop) of an outgoing frame */

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -907,14 +907,13 @@ private:
      */
     bool _write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
 
-    /*
-     * Overloaded beginWrite function to differentiate between RF24 and nrf_to_nrf behavior
+    /**
+     * A function to allow specific implementation for different specializations.
+     * 
+     * This function needs to be defined for each specialization of the ESBNetwork class.
+     * Currently, only RF24 and nrf_to_nrf specializations are supported/implemented.
      */
     bool beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
-
-#if defined(NRF52_RADIO_LIBRARY)
-    bool beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
-#endif
 
     struct logicalToPhysicalStruct
     {

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -909,6 +909,16 @@ private:
      */
     bool _write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
 
+    /*
+     * Overloaded beginWrite function to differentiate between RF24 and nrf_to_nrf behavior
+     */
+    template<typename>
+    struct radioTag
+    {
+    };
+    bool beginWrite(radioTag<RF24>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
+    bool beginWrite(radioTag<nrf_to_nrf>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
+
     struct logicalToPhysicalStruct
     {
         /** The immediate destination (1 hop) of an outgoing frame */

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -910,14 +910,10 @@ private:
     /*
      * Overloaded beginWrite function to differentiate between RF24 and nrf_to_nrf behavior
      */
-    template<typename>
-    struct radioTag
-    {
-    };
-    bool beginWrite(radioTag<RF24>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
+    bool beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
 
 #if defined(NRF52_RADIO_LIBRARY)
-    bool beginWrite(radioTag<nrf_to_nrf>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
+    bool beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
 #endif
 
     struct logicalToPhysicalStruct

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -910,7 +910,7 @@ private:
     /*
      * The main write function where fragmentation and processing of the payload is initiated
      */
-    bool main_write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
+    inline bool main_write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
 
     struct logicalToPhysicalStruct
     {

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -192,7 +192,12 @@
 #define USER_TX_TO_LOGICAL_ADDRESS  3 // network ACK
 #define USER_TX_MULTICAST           4
 
-#define MAX_FRAME_SIZE    32 // Size of individual radio frames
+#if defined NRF52_RADIO_LIBRARY
+    #define MAX_FRAME_SIZE 123 // Size of individual radio frames is larger with NRF52
+#else
+    #define MAX_FRAME_SIZE 32 // Size of individual radio frames
+#endif
+
 #define FRAME_HEADER_SIZE 10 // Size of RF24Network frames - data
 
 /**

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -193,9 +193,9 @@
 #define USER_TX_MULTICAST           4
 
 #if defined NRF52_RADIO_LIBRARY
-    #define MAX_FRAME_SIZE 123 // Size of individual radio frames is larger with NRF52
+    #define MAX_FRAME_BUFFER_SIZE 123 // Size of individual radio frames is larger with NRF52
 #else
-    #define MAX_FRAME_SIZE 32 // Size of individual radio frames
+    #define MAX_FRAME_BUFFER_SIZE 32 // Size of individual radio frames
 #endif
 
 #define FRAME_HEADER_SIZE 10 // Size of RF24Network frames - data
@@ -755,7 +755,7 @@ public:
      * outgoing or incoming).
      * @note The first 8 bytes of this buffer is latest handled frame's RF24NetworkHeader data.
      */
-    uint8_t frame_buffer[MAX_FRAME_SIZE];
+    uint8_t frame_buffer[MAX_FRAME_BUFFER_SIZE];
 
     /**
      * **Linux platforms only**
@@ -851,6 +851,8 @@ protected:
      */
     uint16_t node_address;
 
+    uint8_t max_frame_size;
+
 private:
     /**
      * @brief This function is the second to last stage a frame reaches before transmission.
@@ -939,8 +941,8 @@ private:
 
     radio_t& radio; /** Underlying radio driver, provides link/physical layers */
 
-    uint8_t frame_size;                                                                            /* The outgoing frame's total size including the header info. Ranges [8, MAX_PAYLOAD_SIZE] */
-    const static unsigned int max_frame_payload_size = MAX_FRAME_SIZE - sizeof(RF24NetworkHeader); /* always 24 bytes to compensate for the frame's header */
+    uint8_t frame_size;                                                                      /* The outgoing frame's total size including the header info. Ranges [8, MAX_PAYLOAD_SIZE] */
+    unsigned int max_frame_payload_size = MAX_FRAME_BUFFER_SIZE - sizeof(RF24NetworkHeader); /* always 24 bytes to compensate for the frame's header */
 
 #if defined(RF24_LINUX)
     std::queue<RF24NetworkFrame> frame_queue;

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -960,12 +960,12 @@ private:
 #else // Not Linux:
 
     #if defined(DISABLE_USER_PAYLOADS)
-    uint8_t frame_queue[1]; /** Space for a small set of frames that need to be delivered to the app layer */
+    uint8_t frame_queue[1];  /** Space for a small set of frames that need to be delivered to the app layer */
     #else
     uint8_t frame_queue[MAIN_BUFFER_SIZE]; /** Space for a small set of frames that need to be delivered to the app layer */
     #endif
 
-    uint8_t* next_frame; /** Pointer into the @p frame_queue where we should place the next received frame */
+    uint8_t* next_frame;                                 /** Pointer into the @p frame_queue where we should place the next received frame */
 
     #if !defined(DISABLE_FRAGMENTATION)
     RF24NetworkFrame frag_queue;                         /* a cache for re-assembling incoming message fragments */

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -946,8 +946,6 @@ private:
 
     uint8_t frame_size; /* The outgoing frame's total size including the header info. Ranges [8, MAX_PAYLOAD_SIZE] */
 
-    uint8_t max_frame_size;
-
     unsigned int max_frame_payload_size = MAX_FRAME_SIZE - sizeof(RF24NetworkHeader); /* always 24 bytes to compensate for the frame's header */
 
 #if defined(RF24_LINUX)

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -917,8 +917,11 @@ private:
     {
     };
     bool beginWrite(radioTag<RF24>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
+    
+    #if defined (NRF52_RADIO_LIBRARY)
     bool beginWrite(radioTag<nrf_to_nrf>, RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
-
+    #endif
+    
     struct logicalToPhysicalStruct
     {
         /** The immediate destination (1 hop) of an outgoing frame */

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -1011,7 +1011,7 @@ typedef ESBNetwork<nrf_to_nrf> RF52Network;
 #endif
 
 /**
- * @example helloworld_tx.ino
+ * @example examples/helloworld_tx/helloworld_tx.ino
  *
  * Simplest possible example of using RF24Network. Put this sketch
  * on one node, and helloworld_rx.pde on the other. Tx will send
@@ -1019,7 +1019,7 @@ typedef ESBNetwork<nrf_to_nrf> RF52Network;
  */
 
 /**
- * @example helloworld_rx.ino
+ * @example examples/helloworld_rx/helloworld_rx.ino
  *
  * Simplest possible example of using RF24Network. Put this sketch
  * on one node, and helloworld_tx.pde on the other. Tx will send
@@ -1077,6 +1077,38 @@ typedef ESBNetwork<nrf_to_nrf> RF52Network;
 /**
  * @example Network_Priority_RX.ino
  * An example of handling/prioritizing different types of data passing through the RF24Network
+ */
+
+/**
+ * @example examples/nrf_to_nrf/helloworld_tx/helloworld_tx.ino
+ *
+ * Simplest possible example of using RF24Network with nrf_to_nrf library (instead of RF24).
+ * Put this sketch on one node, and helloworld_tx.pde on the other. Tx will send
+ * Rx a nice message every 2 seconds which rx will print out for us.
+ */
+
+/**
+ * @example examples/nrf_to_nrf/helloworld_rx/helloworld_rx.ino
+ *
+ * Simplest possible example of using RF24Network with nrf_to_nrf library (instead of RF24).
+ * Put this sketch on one node, and helloworld_tx.pde on the other. Tx will send
+ * Rx a nice message every 2 seconds which rx will print out for us.
+ */
+
+/**
+ * @example examples/nrf_to_nrf/helloworld_txEncryption/helloworld_txEncryption.ino
+ *
+ * Simplest possible example of using RF24Network with nrf_to_nrf library (instead of RF24) with encryption.
+ * Put this sketch on one node, and helloworld_tx.pde on the other. Tx will send
+ * Rx a nice message every 2 seconds which rx will print out for us.
+ */
+
+/**
+ * @example examples/nrf_to_nrf/helloworld_rxEncryption/helloworld_rxEncryption.ino
+ *
+ * Simplest possible example of using RF24Network with nrf_to_nrf library (instead of RF24) with encryption.
+ * Put this sketch on one node, and helloworld_tx.pde on the other. Tx will send
+ * Rx a nice message every 2 seconds which rx will print out for us.
  */
 
 #endif // __RF24NETWORK_H__

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -907,6 +907,11 @@ private:
      */
     bool _write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
 
+    /*
+     * The main write function where fragmentation and processing of the payload is initiated
+     */
+    bool main_write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
+
     struct logicalToPhysicalStruct
     {
         /** The immediate destination (1 hop) of an outgoing frame */

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -851,8 +851,6 @@ protected:
      */
     uint16_t node_address;
 
-    uint8_t max_frame_size;
-
 private:
     /**
      * @brief This function is the second to last stage a frame reaches before transmission.
@@ -954,7 +952,10 @@ private:
 
     radio_t& radio; /** Underlying radio driver, provides link/physical layers */
 
-    uint8_t frame_size;                                                               /* The outgoing frame's total size including the header info. Ranges [8, MAX_PAYLOAD_SIZE] */
+    uint8_t frame_size; /* The outgoing frame's total size including the header info. Ranges [8, MAX_PAYLOAD_SIZE] */
+
+    uint8_t max_frame_size;
+
     unsigned int max_frame_payload_size = MAX_FRAME_SIZE - sizeof(RF24NetworkHeader); /* always 24 bytes to compensate for the frame's header */
 
 #if defined(RF24_LINUX)

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -193,9 +193,9 @@
 #define USER_TX_MULTICAST           4
 
 #if defined NRF52_RADIO_LIBRARY
-    #define MAX_FRAME_BUFFER_SIZE 123 // Size of individual radio frames is larger with NRF52
+    #define MAX_FRAME_SIZE 123 // Size of individual radio frames is larger with NRF52
 #else
-    #define MAX_FRAME_BUFFER_SIZE 32 // Size of individual radio frames
+    #define MAX_FRAME_SIZE 32 // Size of individual radio frames
 #endif
 
 #define FRAME_HEADER_SIZE 10 // Size of RF24Network frames - data
@@ -755,7 +755,7 @@ public:
      * outgoing or incoming).
      * @note The first 8 bytes of this buffer is latest handled frame's RF24NetworkHeader data.
      */
-    uint8_t frame_buffer[MAX_FRAME_BUFFER_SIZE];
+    uint8_t frame_buffer[MAX_FRAME_SIZE];
 
     /**
      * **Linux platforms only**
@@ -941,8 +941,8 @@ private:
 
     radio_t& radio; /** Underlying radio driver, provides link/physical layers */
 
-    uint8_t frame_size;                                                                      /* The outgoing frame's total size including the header info. Ranges [8, MAX_PAYLOAD_SIZE] */
-    unsigned int max_frame_payload_size = MAX_FRAME_BUFFER_SIZE - sizeof(RF24NetworkHeader); /* always 24 bytes to compensate for the frame's header */
+    uint8_t frame_size;                                                               /* The outgoing frame's total size including the header info. Ranges [8, MAX_PAYLOAD_SIZE] */
+    unsigned int max_frame_payload_size = MAX_FRAME_SIZE - sizeof(RF24NetworkHeader); /* always 24 bytes to compensate for the frame's header */
 
 #if defined(RF24_LINUX)
     std::queue<RF24NetworkFrame> frame_queue;

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -909,7 +909,7 @@ private:
 
     /**
      * A function to allow specific implementation for different specializations.
-     * 
+     *
      * This function needs to be defined for each specialization of the ESBNetwork class.
      * Currently, only RF24 and nrf_to_nrf specializations are supported/implemented.
      */
@@ -960,12 +960,12 @@ private:
 #else // Not Linux:
 
     #if defined(DISABLE_USER_PAYLOADS)
-    uint8_t frame_queue[1];  /** Space for a small set of frames that need to be delivered to the app layer */
+    uint8_t frame_queue[1]; /** Space for a small set of frames that need to be delivered to the app layer */
     #else
     uint8_t frame_queue[MAIN_BUFFER_SIZE]; /** Space for a small set of frames that need to be delivered to the app layer */
     #endif
 
-    uint8_t* next_frame;                                 /** Pointer into the @p frame_queue where we should place the next received frame */
+    uint8_t* next_frame; /** Pointer into the @p frame_queue where we should place the next received frame */
 
     #if !defined(DISABLE_FRAGMENTATION)
     RF24NetworkFrame frag_queue;                         /* a cache for re-assembling incoming message fragments */

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -913,7 +913,7 @@ private:
      * This function needs to be defined for each specialization of the ESBNetwork class.
      * Currently, only RF24 and nrf_to_nrf specializations are supported/implemented.
      */
-    bool beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
+    inline bool beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
 
     struct logicalToPhysicalStruct
     {

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -907,14 +907,6 @@ private:
      */
     bool _write(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
 
-    /**
-     * A function to allow specific implementation for different specializations.
-     *
-     * This function needs to be defined for each specialization of the ESBNetwork class.
-     * Currently, only RF24 and nrf_to_nrf specializations are supported/implemented.
-     */
-    inline bool beginWrite(RF24NetworkHeader& header, const void* message, uint16_t len, uint16_t writeDirect);
-
     struct logicalToPhysicalStruct
     {
         /** The immediate destination (1 hop) of an outgoing frame */

--- a/examples/nrf_to_nrf/helloworld_rx/helloworld_rx.ino
+++ b/examples/nrf_to_nrf/helloworld_rx/helloworld_rx.ino
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2012 James Coliz, Jr. <maniacbug@ymail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * Update 2014 - TMRh20
+ */
+
+/**
+ * Simplest possible example of using RF24Network,
+ *
+ * RECEIVER NODE
+ * Listens for messages from the transmitter and prints them out.
+ */
+
+#include <nrf_to_nrf.h>
+#include <RF24Network.h>
+
+
+nrf_to_nrf radio;  // nRF24L01(+) radio attached using Getting Started board
+
+RF52Network network(radio);      // Network uses that radio
+const uint16_t this_node = 00;   // Address of our node in Octal format (04, 031, etc)
+const uint16_t other_node = 01;  // Address of the other node in Octal format
+
+struct payload_t {  // Structure of our payload
+  unsigned long ms;
+  unsigned long counter;
+};
+
+
+void setup(void) {
+  Serial.begin(115200);
+  while (!Serial) {
+    // some boards need this because of native USB capability
+  }
+  Serial.println(F("RF24Network/examples/helloworld_rx/"));
+
+  if (!radio.begin()) {
+    Serial.println(F("Radio hardware not responding!"));
+    while (1) {
+      // hold in infinite loop
+    }
+  }
+  radio.setChannel(90);
+  network.begin(/*node address*/ this_node);
+}
+
+void loop(void) {
+
+  network.update();  // Check the network regularly
+
+  while (network.available()) {  // Is there anything ready for us?
+
+    RF24NetworkHeader header;  // If so, grab it and print it out
+    payload_t payload;
+    network.read(header, &payload, sizeof(payload));
+    Serial.print(F("Received packet: counter="));
+    Serial.print(payload.counter);
+    Serial.print(F(", origin timestamp="));
+    Serial.println(payload.ms);
+  }
+}

--- a/examples/nrf_to_nrf/helloworld_rxEncryption/helloworld_rxEncryption.ino
+++ b/examples/nrf_to_nrf/helloworld_rxEncryption/helloworld_rxEncryption.ino
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2012 James Coliz, Jr. <maniacbug@ymail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * Update 2014 - TMRh20
+ */
+
+/**
+ * Simplest possible example of using RF24Network,
+ *
+ * RECEIVER NODE
+ * Listens for messages from the transmitter and prints them out.
+ */
+
+#include <nrf_to_nrf.h>
+#include <RF24Network.h>
+
+//Set up our encryption key
+uint8_t myKey[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6 };
+
+nrf_to_nrf radio;  // nRF24L01(+) radio attached using Getting Started board
+
+RF52Network network(radio);      // Network uses that radio
+const uint16_t this_node = 00;   // Address of our node in Octal format (04, 031, etc)
+const uint16_t other_node = 01;  // Address of the other node in Octal format
+
+struct payload_t {  // Structure of our payload
+  unsigned long ms;
+  unsigned long counter;
+};
+
+
+void setup(void) {
+  Serial.begin(115200);
+  while (!Serial) {
+    // some boards need this because of native USB capability
+  }
+  Serial.println(F("RF24Network/examples/helloworld_rx/"));
+
+  if (!radio.begin()) {
+    Serial.println(F("Radio hardware not responding!"));
+    while (1) {
+      // hold in infinite loop
+    }
+  }
+
+  radio.setKey(myKey);               // Set our key and IV
+  radio.enableEncryption = true;     // Enable encryption
+  radio.enableDynamicPayloads(123);  //This is important to call so the encryption overhead will not be included in the 32-byte limit
+                                     //To overcome the 32-byte limit, edit RF24Network.h and set MAX_FRAME_SIZE to 111
+  radio.setChannel(90);
+  network.begin(/*node address*/ this_node);
+}
+
+void loop(void) {
+
+  network.update();  // Check the network regularly
+
+  while (network.available()) {  // Is there anything ready for us?
+
+    RF24NetworkHeader header;  // If so, grab it and print it out
+    payload_t payload;
+    network.read(header, &payload, sizeof(payload));
+    Serial.print(F("Received packet: counter="));
+    Serial.print(payload.counter);
+    Serial.print(F(", origin timestamp="));
+    Serial.println(payload.ms);
+  }
+}

--- a/examples/nrf_to_nrf/helloworld_tx/helloworld_tx.ino
+++ b/examples/nrf_to_nrf/helloworld_tx/helloworld_tx.ino
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2012 James Coliz, Jr. <maniacbug@ymail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * Update 2014 - TMRh20
+ */
+
+/**
+ * Simplest possible example of using RF24Network
+ *
+ * TRANSMITTER NODE
+ * Every 2 seconds, send a payload to the receiver node.
+ */
+
+#include <nrf_to_nrf.h>
+#include <RF24Network.h>
+
+nrf_to_nrf radio;  // nRF24L01(+) radio attached using Getting Started board
+
+RF52Network network(radio);  // Network uses that radio
+
+const uint16_t this_node = 01;   // Address of our node in Octal format
+const uint16_t other_node = 00;  // Address of the other node in Octal format
+
+const unsigned long interval = 2000;  // How often (in ms) to send 'hello world' to the other unit
+
+unsigned long last_sent;     // When did we last send?
+unsigned long packets_sent;  // How many have we sent already
+
+
+struct payload_t {  // Structure of our payload
+  unsigned long ms;
+  unsigned long counter;
+};
+
+void setup(void) {
+  Serial.begin(115200);
+  while (!Serial) {
+    // some boards need this because of native USB capability
+  }
+  Serial.println(F("RF24Network/examples/helloworld_tx/"));
+
+  if (!radio.begin()) {
+    Serial.println(F("Radio hardware not responding!"));
+    while (1) {
+      // hold in infinite loop
+    }
+  }
+  radio.setChannel(90);
+  network.begin(/*node address*/ this_node);
+}
+
+void loop() {
+
+  network.update();  // Check the network regularly
+
+  unsigned long now = millis();
+
+  // If it's time to send a message, send it!
+  if (now - last_sent >= interval) {
+    last_sent = now;
+
+    Serial.print(F("Sending... "));
+    payload_t payload = { millis(), packets_sent++ };
+    RF24NetworkHeader header(/*to node*/ other_node);
+    bool ok = network.write(header, &payload, sizeof(payload));
+    Serial.println(ok ? F("ok.") : F("failed."));
+  }
+}

--- a/examples/nrf_to_nrf/helloworld_txEncryption/helloworld_txEncryption.ino
+++ b/examples/nrf_to_nrf/helloworld_txEncryption/helloworld_txEncryption.ino
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2012 James Coliz, Jr. <maniacbug@ymail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * Update 2014 - TMRh20
+ */
+
+/**
+ * Simplest possible example of using RF24Network
+ *
+ * TRANSMITTER NODE
+ * Every 2 seconds, send a payload to the receiver node.
+ */
+
+#include <nrf_to_nrf.h>
+#include <RF24Network.h>
+
+//Set up our encryption key
+uint8_t myKey[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6 };
+
+nrf_to_nrf radio;  // nRF24L01(+) radio attached using Getting Started board
+
+RF52Network network(radio);  // Network uses that radio
+
+const uint16_t this_node = 01;   // Address of our node in Octal format
+const uint16_t other_node = 00;  // Address of the other node in Octal format
+
+const unsigned long interval = 2000;  // How often (in ms) to send 'hello world' to the other unit
+
+unsigned long last_sent;     // When did we last send?
+unsigned long packets_sent;  // How many have we sent already
+
+
+struct payload_t {  // Structure of our payload
+  unsigned long ms;
+  unsigned long counter;
+};
+
+void setup(void) {
+  Serial.begin(115200);
+  while (!Serial) {
+    // some boards need this because of native USB capability
+  }
+  Serial.println(F("RF24Network/examples/helloworld_tx/"));
+
+  if (!radio.begin()) {
+    Serial.println(F("Radio hardware not responding!"));
+    while (1) {
+      // hold in infinite loop
+    }
+  }
+
+  radio.setKey(myKey);               // Set our key and IV
+  radio.enableEncryption = true;     // Enable encryption
+  radio.enableDynamicPayloads(123);  //This is important to call so the encryption overhead will not be included in the 32-byte limit
+                                     //To overcome the 32-byte limit, edit RF24Network.h and set MAX_FRAME_SIZE to 111
+  radio.setChannel(90);
+  network.begin(/*node address*/ this_node);
+}
+
+void loop() {
+
+  network.update();  // Check the network regularly
+
+  unsigned long now = millis();
+
+  // If it's time to send a message, send it!
+  if (now - last_sent >= interval) {
+    last_sent = now;
+
+    Serial.print(F("Sending... "));
+    payload_t payload = { millis(), packets_sent++ };
+    RF24NetworkHeader header(/*to node*/ other_node);
+    bool ok = network.write(header, &payload, sizeof(payload));
+    Serial.println(ok ? F("ok.") : F("failed."));
+  }
+}


### PR DESCRIPTION
It seems we missed configuring the `MAX_FRAME_SIZE` with NRF52 devices in V2.0.

This fix clears that issue up.