### PR TITLE
Fix write to pipe

### DIFF
--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -1027,12 +1027,12 @@ bool ESBNetwork<radio_t>::write_to_pipe(uint16_t node, uint8_t pipe, bool multic
     ok = radio.writeFast(frame_buffer, frame_size, 0);
 
     if (!ok) {
-       radio.txStandBy(txTimeout);
-       if(!(networkFlags & FLAG_FAST_FRAG)){
-         radio.setAutoAck(0, 0);
-       }
-    }else
-    if ( (!(networkFlags & FLAG_FAST_FRAG)) || frame_buffer[6] == NETWORK_LAST_FRAGMENT) {
+        radio.txStandBy(txTimeout);
+        if (!(networkFlags & FLAG_FAST_FRAG)) {
+            radio.setAutoAck(0, 0);
+        }
+    }
+    else if ((!(networkFlags & FLAG_FAST_FRAG)) || frame_buffer[6] == NETWORK_LAST_FRAGMENT) {
         ok = radio.txStandBy(txTimeout);
     }
     /*


### PR DESCRIPTION
The main purpose of this fix is to return failure on a single write failure.

Previous behavior would "skip" the current payload and return the status of previously sent packets in the TX FIFO.

Closes #246 