### PR TITLE
Add new type - RF24NETWORK_CORRUPTION 161

### DIFF
--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -136,7 +136,6 @@ uint8_t ESBNetwork<radio_t>::update(void)
 
     while (radio.available()) {
         if (millis() > timeout) {
-            radio.flush_rx();
             return NETWORK_OVERRUN;
         }
 #if defined(ENABLE_DYNAMIC_PAYLOADS) && !defined(XMEGA_D3)
@@ -144,6 +143,10 @@ uint8_t ESBNetwork<radio_t>::update(void)
 #else
         frame_size = MAX_FRAME_SIZE;
 #endif
+
+        if (!frame_size) {
+            return NETWORK_CORRUPTION;
+        }
 
         // Fetch the payload, and see if this was the last one.
         radio.read(frame_buffer, frame_size);

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -123,9 +123,14 @@
 //#define NETWORK_ACK_REQUEST 192
 
 /**
- * Messages of this type indicate the network is being overrun with data & the RX FIFO has been flushed.
+ * Messages of this type indicate the network is being overrun with data.
  **/
 #define NETWORK_OVERRUN 160
+
+/**
+ * Messages of this type indicate radio data corruption & the RX FIFO has been flushed.
+ **/
+#define NETWORK_CORRUPTION 161
 
 /**
  * Messages of this type signal the sender that a network-wide transmission has been completed.


### PR DESCRIPTION
- Add NETWORK_CORRUPTION type
- With latest RF24 fix, no longer need to flush_rx() if available is stuck in a loop, just return NETWORK_OVERRUN
- Needs to be pushed after the RF24 Dynamic Payloads Fix: 
https://github.com/nRF24/RF24/pull/1036