### PR TITLE
Add delay during fragmentation for nRF52x

### DIFF
--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -788,6 +788,9 @@ bool ESBNetwork<radio_t>::main_write(RF24NetworkHeader& header, const void* mess
             retriesPerFrag = 0;
             fragment_id--;
             msgCount++;
+    #if THROTTLE_FRAG > 0
+            delayMicroseconds(THROTTLE_FRAG);
+    #endif
         }
 
         //if(writeDirect != NETWORK_AUTO_ROUTING){ delay(2); } //Delay 2ms between sending multicast payloads

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -40,6 +40,10 @@
  */
 #define NUM_PIPES 6
 
+/**
+ * Add a slight delay (63 uS) when sending fragmented payloads with nRF52x & nrf_to_nrf library
+ * This is required because the nRF52x is slightly faster than the nRF24L01
+ */
 #ifndef THROTTLE_FRAG
     #ifdef NRF52_RADIO_LIBRARY
         #define THROTTLE_FRAG 63

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -40,6 +40,14 @@
  */
 #define NUM_PIPES 6
 
+#ifndef THROTTLE_FRAG
+    #ifdef NRF52_RADIO_LIBRARY
+        #define THROTTLE_FRAG 63
+    #else
+        #define THROTTLE_FRAG 0
+    #endif
+#endif
+
 #if !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny84__)
 
     /********** USER CONFIG - non ATTiny **************/


### PR DESCRIPTION
- nRF52x is slightly faster than nRF24, make up for this with a delay while sending fragmented payloads
- I increased the delay to 63uS since 60uS was the minimum that worked

Closes #252