### PR TITLE
Revert throttle frag

### DIFF
--- a/RF24Network.cpp
+++ b/RF24Network.cpp
@@ -788,9 +788,6 @@ bool ESBNetwork<radio_t>::main_write(RF24NetworkHeader& header, const void* mess
             retriesPerFrag = 0;
             fragment_id--;
             msgCount++;
-    #if THROTTLE_FRAG > 0
-            delayMicroseconds(THROTTLE_FRAG);
-    #endif
         }
 
         //if(writeDirect != NETWORK_AUTO_ROUTING){ delay(2); } //Delay 2ms between sending multicast payloads

--- a/RF24Network.h
+++ b/RF24Network.h
@@ -228,18 +228,6 @@
  */
 #define FLAG_NO_POLL 8
 
-/**
- * Add a slight delay (63 uS) when sending fragmented payloads with nRF52x & nrf_to_nrf library
- * This is required because the nRF52x is slightly faster than the nRF24L01
- */
-#ifndef THROTTLE_FRAG
-    #ifdef NRF52_RADIO_LIBRARY
-        #define THROTTLE_FRAG 63
-    #else
-        #define THROTTLE_FRAG 0
-    #endif
-#endif
-
 class RF24;
 #if defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_ARCH_NRF52840) || defined(ARDUINO_ARCH_NRF52833)
 class nrf_to_nrf;

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -40,18 +40,6 @@
  */
 #define NUM_PIPES 6
 
-/**
- * Add a slight delay (63 uS) when sending fragmented payloads with nRF52x & nrf_to_nrf library
- * This is required because the nRF52x is slightly faster than the nRF24L01
- */
-#ifndef THROTTLE_FRAG
-    #ifdef NRF52_RADIO_LIBRARY
-        #define THROTTLE_FRAG 63
-    #else
-        #define THROTTLE_FRAG 0
-    #endif
-#endif
-
 #if !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny84__)
 
     /********** USER CONFIG - non ATTiny **************/

--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -40,6 +40,18 @@
  */
 #define NUM_PIPES 6
 
+/**
+ * Add a slight delay (63 uS) when sending fragmented payloads with nRF52x & nrf_to_nrf library
+ * This is required because the nRF52x is slightly faster than the nRF24L01
+ */
+#ifndef THROTTLE_FRAG
+    #ifdef NRF52_RADIO_LIBRARY
+        #define THROTTLE_FRAG 63
+    #else
+        #define THROTTLE_FRAG 0
+    #endif
+#endif
+
 #if !defined(__AVR_ATtiny85__) && !defined(__AVR_ATtiny84__)
 
     /********** USER CONFIG - non ATTiny **************/


### PR DESCRIPTION
Since I figured out how to use TIFS (Interframe Spacing) in the nrf_to_nrf library, this change is no longer required in RF24Network. 

I believe the fix SHOULD be made at the radio layer because it also affects that layer when sending consecutive payloads to an nRF24L01 device.

See https://github.com/TMRh20/nrf_to_nrf/pull/44

This change should probably wait until after a release is made for nrf_to_nrf with the above changes