### PR TITLE
Larger payloads on faster devices

### DIFF
--- a/RF24Network_config.h
+++ b/RF24Network_config.h
@@ -61,7 +61,7 @@
      * the actual transmitted payload to 24 bytes (which is also the default behavior on ATTiny devices).
      */
     #ifndef MAX_PAYLOAD_SIZE
-        #if defined linux || defined __linux
+        #if defined linux || defined __linux || !defined F_CPU || F_CPU >= 50000000
             #define MAX_PAYLOAD_SIZE 1514
         #else
             #define MAX_PAYLOAD_SIZE 144


### PR DESCRIPTION
Set MAX_PAYLOAD_SIZE to 1514 for devices 50MHz or faster

Supports recent changes to RF24Ethernet utilizing the lwIP IP Stack for faster devices.