### PR TITLE
Support larger payload sizes

### DIFF
--- a/RF24Network.h
+++ b/RF24Network.h
@@ -203,7 +203,7 @@
 #define USER_TX_MULTICAST           4
 
 #if defined NRF52_RADIO_LIBRARY
-    #define RF24NETWORK_MAX_FRAME_SIZE 123 // Size of individual radio frames is larger with NRF52
+    #define RF24NETWORK_MAX_FRAME_SIZE 254 // Size of individual radio frames is larger with NRF52
 #else
     #define RF24NETWORK_MAX_FRAME_SIZE 32 // Size of individual radio frames
 #endif


### PR DESCRIPTION
- Realized the 127-byte limit is not applicable to nRF52840 in ESB mode, it apparently supports up to 255 byte payloads, 254 with 16-bit CRC & DPL I think, need to test further.
- This supports nRF54l15 large payload sizes also